### PR TITLE
fix: child slice selectors only selecting first matching index

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -65,7 +65,6 @@ jobs:
             target/
           key: book-cargo-${{ hashFiles('**/Cargo.toml') }}
       - name: cargo install mdbook
-        if: steps.cache-restore-cargo.outputs.cache-hit != 'true'
         uses: baptiste0928/cargo-install@94e1849646e5797d0c8b34d8e525124ae9ae1d86 # v3.0.1
         with:
           # Name of the crate to install
@@ -73,7 +72,6 @@ jobs:
         env:
           CARGO_TARGET_DIR: target/
       - name: cargo install mdbook-katex
-        if: steps.cache-restore-cargo.outputs.cache-hit != 'true'
         uses: baptiste0928/cargo-install@94e1849646e5797d0c8b34d8e525124ae9ae1d86 # v3.0.1
         with:
           # Name of the crate to install

--- a/.github/workflows/clusterfuzzlite-cron.yml
+++ b/.github/workflows/clusterfuzzlite-cron.yml
@@ -38,7 +38,7 @@ jobs:
       uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        fuzz-seconds: 600
+        fuzz-seconds: 1200
         mode: 'prune'
         output-sarif: true
         storage-repo: https://${{ secrets.CLUSTERFUZZLITE_STORAGE_TOKEN }}@github.com/rsonquery/rsonpath-fuzz-storage.git
@@ -64,7 +64,7 @@ jobs:
       uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        fuzz-seconds: 600
+        fuzz-seconds: 1200
         mode: 'coverage'
         sanitizer: 'coverage'
         storage-repo: https://${{ secrets.CLUSTERFUZZLITE_STORAGE_TOKEN }}@github.com/rsonquery/rsonpath-fuzz-storage.git

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -138,7 +138,6 @@ jobs:
             target/
           key: ${{ matrix.toolchain }}-${{ matrix.target_triple }}-cargo-${{ hashFiles('**/Cargo.toml') }}
       - name: cargo install cargo-hack
-        if: steps.cache-restore-cargo.outputs.cache-hit != 'true'
         uses: baptiste0928/cargo-install@94e1849646e5797d0c8b34d8e525124ae9ae1d86 # v3.0.1
         with:
           # Name of the crate to install

--- a/crates/rsonpath-lib/src/automaton.rs
+++ b/crates/rsonpath-lib/src/automaton.rs
@@ -122,6 +122,15 @@ impl ArrayTransitionLabel {
             Self::Slice(s) => s.contains(index),
         }
     }
+
+    fn matches_at_most_once(&self) -> bool {
+        match self {
+            Self::Index(_) => true,
+            Self::Slice(slice) => {
+                slice.step == JsonUInt::ZERO && slice.end.map_or(false, |end| slice.start.as_u64() + 1 >= end.as_u64())
+            }
+        }
+    }
 }
 
 impl From<JsonUInt> for ArrayTransitionLabel {

--- a/crates/rsonpath-test/documents/toml/lists.toml
+++ b/crates/rsonpath-test/documents/toml/lists.toml
@@ -377,3 +377,31 @@ nodes = ['''[
                 0
             ]
         ]''']
+
+[[queries]]
+query = "$[1:3]"
+description = "select the second and third elements"
+
+[queries.results]
+count = 2
+spans = [[31, 33], [39, 278]]
+nodes = [
+    '[]',
+    '''[
+        [],
+        [
+            [
+                [],
+                0
+            ],
+            [
+                [],
+                0
+            ],
+            [
+                [],
+                0
+            ]
+        ]
+    ]'''
+]


### PR DESCRIPTION
## Short description

Fixed a bug where the compiler would erronously mark states with a single slice transition as unitary, even though such transitions could match more than one index.

## Checklist

All of these should be ticked off before you submit the PR.

- [x] I ran `just verify` locally and it succeeded.
- [x] Issue was given <span style="color: #FF4400">go ahead</span> and is linked above **OR** I have included justification for a minor change.
- [x] Unit tests for my changes are included **OR** no functionality was changed.