### PR TITLE
split long doc comment in `approx_span`

### DIFF
--- a/crates/rsonpath-lib/src/result/approx_span.rs
+++ b/crates/rsonpath-lib/src/result/approx_span.rs
@@ -1,4 +1,5 @@
 //! [`Recorder`] implementation finding the starts and approximate ends of all matches.
+//!
 //! Faster than a full [`NodesRecorder`](super::nodes::NodesRecorder), but the span
 //! may include trailing whitespace after the actual matched value.
 use super::{output_queue::OutputQueue, *};


### PR DESCRIPTION
## Short description

New clippy lint introduced in nightly (`clippy::too-long-first-doc-paragraph`) was being triggered on the top module comment for `result::approx_span`.

## Checklist

All of these should be ticked off before you submit the PR.

- [x] I ran `just verify` locally and it succeeded.
- [x] Issue was given <span style="color: #FF4400">go ahead</span> and is linked above **OR** I have included justification for a minor change.
- [x] Unit tests for my changes are included **OR** no functionality was changed.