### PR TITLE
rollup actions bumps from dependabot into a single commit

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -14,19 +14,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Force remove rsonpath-lib patch from Cargo.toml
       run: sed -i '/^\[patch.crates-io\]/d' ./Cargo.toml && sed -i '/^rsonpath-lib = { path = .*$/d' ./Cargo.toml
     - name: Install lld
       run: sudo apt install lld
-    - uses: actions/setup-java@v3.6.0
+    - uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b # v4.5.0
       name: Setup Java JDK
       with:
         distribution: temurin
         java-version: 17
     - name: Cache restore
       id: cache-restore
-      uses: actions/cache@v3
+      uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
       with:
         path: |
           ~/.cargo/bin/
@@ -47,12 +47,12 @@ jobs:
     name: Clippy (stable)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Force remove rsonpath-lib patch from Cargo.toml
       run: sed -i '/^\[patch.crates-io\]/d' ./Cargo.toml && sed -i '/^rsonpath-lib = { path = .*$/d' ./Cargo.toml
     - name: Install lld
       run: sudo apt install lld
-    - uses: actions/setup-java@v3.6.0
+    - uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b # v4.5.0
       name: Setup Java JDK
       with:
         distribution: temurin
@@ -87,12 +87,12 @@ jobs:
     name: Clippy (nightly)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Force remove rsonpath-lib patch from Cargo.toml
       run: sed -i '/^\[patch.crates-io\]/d' ./Cargo.toml && sed -i '/^rsonpath-lib = { path = .*$/d' ./Cargo.toml
     - name: Install lld
       run: sudo apt install lld
-    - uses: actions/setup-java@v3.6.0
+    - uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b # v4.5.0
       name: Setup Java JDK
       with:
         distribution: temurin

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -43,7 +43,7 @@ jobs:
             static.rust-lang.org:443
 
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
       - name: Install Rust toolchain (${{ matrix.toolchain }})
@@ -55,7 +55,7 @@ jobs:
         run: rustup override set stable
       - name: Cache restore (Cargo)
         id: cache-restore-cargo
-        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/clusterfuzzlite-batch.yml
+++ b/.github/workflows/clusterfuzzlite-batch.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         egress-policy: audit
     - name: Checkout sources
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         submodules: true
     - name: Report crash

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -26,6 +26,6 @@ jobs:
             api.github.com:443
 
       - name: "Checkout Repository"
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: "Dependency Review"
         uses: actions/dependency-review-action@a6993e2c61fd5dc440b409aa1d6904921c5e1894 # v4.3.5

--- a/.github/workflows/nix-shell.yml
+++ b/.github/workflows/nix-shell.yml
@@ -28,7 +28,7 @@ jobs:
             releases.nixos.org:443
             tarballs.nixos.org:443
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
       - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout source
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
       - name: Remove config
@@ -97,7 +97,7 @@ jobs:
       - name: Cache restore (MinGW)
         id: cache-restore-mingw
         if: matrix.needs-mingw != ''
-        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: |
             C:\ProgramData\chocolatey\lib\mingw

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Cache restore (MinGW)
         id: cache-restore-mingw
         if: matrix.needs-mingw != ''
-        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: |
             C:\ProgramData\chocolatey\lib\mingw
@@ -116,7 +116,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt install lld
       - name: Checkout sources
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
       - name: Install Rust toolchain (${{ matrix.toolchain }})
@@ -267,7 +267,7 @@ jobs:
         env:
           RUSTFLAGS: "-C link-arg=-fuse-ld=lld --deny warnings"
       - name: Clippy all features
-        uses: auguwu/clippy-action@a1f4eaac010d8f420818674bdd5eb9937e7efe26 # v1.3.0
+        uses: auguwu/clippy-action@8dc2ea8f7d624bf06a22145cc62fd8bc7d6b0a3e # v1.3.0
         with:
           deny: warnings
           all-features: true

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -36,7 +36,7 @@ jobs:
           egress-policy: audit
 
       - name: "Checkout code"
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/test-codegen.yml
+++ b/.github/workflows/test-codegen.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install lld
         run: sudo apt install lld
       - name: Checkout sources
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: true
       - name: Install Rust toolchain (stable)
@@ -53,7 +53,7 @@ jobs:
         run: rustup override set stable
       - name: Cache restore (Cargo)
         id: cache-restore-cargo
-        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: |
             ~/.cargo/bin/


### PR DESCRIPTION
## Short description

chore(ci): bump auguwu/clippy-action from a1f4eaac010d8f420818674bdd5eb9937e7efe26 to 8dc2ea8f7d624bf06a22145cc62fd8bc7d6b0a3e

chore(ci): bump actions/checkout from 3 to 4

chore(ci): bump actions/cache from 3 to 4

chore(ci): bump actions/setup-java from 3.6.0 to 4.5.0

## Checklist

All of these should be ticked off before you submit the PR.

- [x] I ran `just verify` locally and it succeeded.
- [x] Issue was given <span style="color: #FF4400">go ahead</span> and is linked above **OR** I have included justification for a minor change.
- [x] Unit tests for my changes are included **OR** no functionality was changed.