### PR TITLE
Added StringPattern and made Automaton no longer borrow the query

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -6,7 +6,7 @@ default: (build-all "release")
 # === INIT ===
 
 # Initialize the repository for development.
-init: check-cargo hooks-init checkout-benchmarks
+init: check-cargo hooks-init checkout-submodules
 
 # Check if cargo is installed and install it from rustup if not.
 [private]
@@ -28,9 +28,14 @@ init: check-cargo hooks-init checkout-benchmarks
 
 # Checkout and populate the benchmarks repository, excluding datasets.
 [private]
-checkout-benchmarks:
+@checkout-submodules:
     git submodule init
     git submodule update
+
+# Initialize the benchmarks crate.
+[private]
+@init-benchmarks:
+    cd crates/rsonpath-benchmarks && just init
 
 # === BUILD ===
 
@@ -247,7 +252,7 @@ hook-pre-commit:
     (just verify-fmt && just verify-check);
 
 [private]
-@hook-post-checkout: checkout-benchmarks
+@hook-post-checkout: checkout-submodules
 
 [private]
 assert-benchmarks-committed:

--- a/crates/rsonpath-benchmarks/Cargo.toml
+++ b/crates/rsonpath-benchmarks/Cargo.toml
@@ -33,7 +33,6 @@ libc = "0.2.168"
 lazy_static = "1.5.0"
 serde_json = "1.0.134"
 sha2 = "0.10.8"
-ouroboros = "0.18.4"
 reqwest = { version = "0.12.9", features = ["blocking"] }
 rsonpath-lib = { version = "0.9.1", default-features = false }
 rsonpath-syntax = { version = "0.3.1", default-features = false }

--- a/crates/rsonpath-benchmarks/Justfile
+++ b/crates/rsonpath-benchmarks/Justfile
@@ -1,6 +1,9 @@
 [private]
 default: build-bench
 
+init:
+  cd ./src/implementations/jsurferShim && gradle wrapper
+
 # === BUILD ===
 
 alias b := build-bench

--- a/crates/rsonpath-benchmarks/README.md
+++ b/crates/rsonpath-benchmarks/README.md
@@ -12,60 +12,21 @@ Benchmark suite for [`rsonpath`](https://github.com/v0ldek/rsonpath).
 
 ## Prerequisites
 
-By default, the benches are performed against a released version of `rsonpath`.
-Usually you might want to run it against the local version to test your changes.
-To do that, pass a [patch config value] to `cargo`:
+By default, the benches are performed against the local version of `rsonpath` in the local repository.
 
-```ini
---config 'patch.crates-io.rsonpath.path = "../rsonpath"'
-```
-
-Additionally:
-
-1. An appropriate C++ compiler is required for the [`cc` crate](https://lib.rs/crates/cc) to compile the
-   JSONSki code.
-2. JDK of version at least 8 is required and your `JAVA_HOME` environment variable must be set
+1. JDK of version at least 8 is required and your `JAVA_HOME` environment variable must be set
    to its location.
+2. You need `gradle` to create the required wrapper JAR to build JSurfer. To install `gradle` it's recommended to use
+[`SDKMan`](https://sdkman.io/): `sdk install gradle 7.5`. After that is done, run `just init` in the root of `rsonpath-benchmarks`.
+This needs to be done only once.
 
 On x86_64 Ubuntu the latters can be done by installing `openjdk-17-jdk` and exporting `JAVA_HOME` as
 `/usr/lib/jvm/java-1.17.0-openjdk-amd64`.
 
 ### Download the dataset
 
-On a UNIX system with `wget` installed run the script `sh dl.sh`.
-You can also manually download the dataset and put the JSON files in the correct folder.
-
-For more information, refers to:
-
-* AST: [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7229269.svg)](https://doi.org/10.5281/zenodo.7229269)
-* Twitter: [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7229287.svg)](https://doi.org/10.5281/zenodo.7229287)
-* Crossref: [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7229287.svg)](https://doi.org/10.5281/zenodo.7231920)
-
-For the benchmark to work, the directory layout should be as follows:
-
-```ini
-── data
-   ├── ast
-   │   └── ast.json
-   ├── crossref
-   │   ├── crossref0.json
-   │   ├── crossref16.json
-   │   ├── crossref1.json
-   │   ├── crossref2.json
-   │   ├── crossref4.json
-   │   └── crossref8.json
-   └── twitter
-       └── twitter.json
-```
-
-The sha256sum of the JSON files, for reference:
-
-* `c3ff840d153953ee08c1d9622b20f8c1dc367ae2abcb9c85d44100c6209571af  ast/ast.json`
-* `f76da4fbd5c18889012ab9bbc222cc439b4b28f458193d297666f56fc69ec500  crossref/crossref/crossref1.json`
-* `95e0038e46ce2e94a0f9dde35ec7975280194220878f83436e320881ccd252b4  crossref/crossref/crossref2.json`
-* `f14e65d4f8df3c9144748191c1e9d46a030067af86d0cc03cc67f22149143c5d  twitter/twitter.json`
-
-TODO: checksums of other crossrefs
+Datasets are automatically downloaded on demand when an appropriate benchmark is ran. The datasets are also
+automatically checked against their known SHA256 checksum to verify integrity.
 
 ## Usage
 
@@ -82,12 +43,6 @@ cargo bench --bench <dataset> --no-default-features
 ```
 
 The folder `target/criterion` contains all the information needed to plot the experiment.
-
-As a reminder, to test against local changes instead of a crates.io version:
-
-```bash
-cargo bench --bench <dataset> --config 'patch.crates-io.rsonpath.path = "../rsonpath"'
-```
 
 ## Plotting
 

--- a/crates/rsonpath-lib/src/automaton.rs
+++ b/crates/rsonpath-lib/src/automaton.rs
@@ -8,20 +8,20 @@ mod state;
 
 pub use state::{State, StateAttributes};
 
-use crate::{automaton::error::CompilerError, debug};
+use crate::{automaton::error::CompilerError, debug, string_pattern::StringPattern};
 use nfa::NondeterministicAutomaton;
-use rsonpath_syntax::{num::JsonUInt, str::JsonString, JsonPathQuery};
+use rsonpath_syntax::{num::JsonUInt, JsonPathQuery};
 use smallvec::SmallVec;
-use std::{fmt::Display, ops::Index};
+use std::{fmt::Display, ops::Index, rc::Rc};
 
 /// A minimal, deterministic automaton representing a JSONPath query.
 #[derive(Debug, PartialEq, Eq)]
-pub struct Automaton<'q> {
-    states: Vec<StateTable<'q>>,
+pub struct Automaton {
+    states: Vec<StateTable>,
 }
 
-/// Transition when a JSON member name matches a [`JsonString`]i.
-pub type MemberTransition<'q> = (&'q JsonString, State);
+/// Transition when a JSON member name matches a [`StringPattern`].
+pub type MemberTransition = (Rc<StringPattern>, State);
 
 /// Transition on elements of an array with indices specified by either a single index
 /// or a simple slice expression.
@@ -45,9 +45,9 @@ pub(super) enum ArrayTransitionLabel {
 /// Contains transitions triggered by matching member names or array indices, and a fallback transition
 /// triggered when none of the labelled transitions match.
 #[derive(Debug)]
-pub struct StateTable<'q> {
+pub struct StateTable {
     attributes: StateAttributes,
-    member_transitions: SmallVec<[MemberTransition<'q>; 2]>,
+    member_transitions: SmallVec<[MemberTransition; 2]>,
     array_transitions: SmallVec<[ArrayTransition; 2]>,
     fallback_state: State,
 }
@@ -59,7 +59,7 @@ pub(crate) struct SimpleSlice {
     step: JsonUInt,
 }
 
-impl Default for StateTable<'_> {
+impl Default for StateTable {
     #[inline]
     fn default() -> Self {
         Self {
@@ -71,7 +71,7 @@ impl Default for StateTable<'_> {
     }
 }
 
-impl PartialEq for StateTable<'_> {
+impl PartialEq for StateTable {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         return self.fallback_state == other.fallback_state
@@ -88,10 +88,10 @@ impl PartialEq for StateTable<'_> {
     }
 }
 
-impl Eq for StateTable<'_> {}
+impl Eq for StateTable {}
 
-impl<'q> Index<State> for Automaton<'q> {
-    type Output = StateTable<'q>;
+impl Index<State> for Automaton {
+    type Output = StateTable;
 
     #[inline(always)]
     fn index(&self, index: State) -> &Self::Output {
@@ -149,7 +149,7 @@ impl From<SimpleSlice> for ArrayTransitionLabel {
     }
 }
 
-impl<'q> Automaton<'q> {
+impl Automaton {
     /// Convert a [`JsonPathQuery`] into a minimal deterministic automaton.
     ///
     /// # Errors
@@ -158,10 +158,10 @@ impl<'q> Automaton<'q> {
     /// - [`CompilerError::NotSupported`] raised if the query contains elements
     ///   not yet supported by the compiler.
     #[inline]
-    pub fn new(query: &'q JsonPathQuery) -> Result<Self, CompilerError> {
+    pub fn new(query: &JsonPathQuery) -> Result<Self, CompilerError> {
         let nfa = NondeterministicAutomaton::new(query)?;
         debug!("NFA: {}", nfa);
-        Automaton::minimize(nfa)
+        Self::minimize(nfa)
     }
 
     /// Returns whether this automaton represents the select-root JSONPath query ('$').
@@ -389,12 +389,12 @@ impl<'q> Automaton<'q> {
         self[state].attributes.is_unitary()
     }
 
-    fn minimize(nfa: NondeterministicAutomaton<'q>) -> Result<Self, CompilerError> {
+    fn minimize(nfa: NondeterministicAutomaton) -> Result<Self, CompilerError> {
         minimizer::minimize(nfa)
     }
 }
 
-impl<'q> StateTable<'q> {
+impl StateTable {
     /// Returns the state to which a fallback transition leads.
     ///
     /// A fallback transition is the catch-all transition triggered
@@ -421,7 +421,7 @@ impl<'q> StateTable<'q> {
     /// to the contained [`State`].
     #[must_use]
     #[inline(always)]
-    pub fn member_transitions(&self) -> &[MemberTransition<'q>] {
+    pub fn member_transitions(&self) -> &[MemberTransition] {
         &self.member_transitions
     }
 }
@@ -442,7 +442,7 @@ impl Display for ArrayTransitionLabel {
     }
 }
 
-impl Display for Automaton<'_> {
+impl Display for Automaton {
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "digraph {{")?;
@@ -503,7 +503,12 @@ impl Display for Automaton<'_> {
                 }
             }
             for (label, state) in &transitions.member_transitions {
-                writeln!(f, "  {i} -> {} [label=\"{}\"]", state.0, label.unquoted())?
+                writeln!(
+                    f,
+                    "  {i} -> {} [label=\"{}\"]",
+                    state.0,
+                    std::str::from_utf8(label.unquoted()).expect("labels to be valid utf8")
+                )?
             }
             writeln!(f, "  {i} -> {} [label=\"*\"]", transitions.fallback_state.0)?;
         }

--- a/crates/rsonpath-lib/src/automaton/minimizer.rs
+++ b/crates/rsonpath-lib/src/automaton/minimizer.rs
@@ -1,5 +1,7 @@
 //! Determinization and minimization of an NFA into the final DFA used by the engines.
 
+use std::rc::Rc;
+
 // NOTE: Some comments in this module are outdated, because the minimizer doesn't
 // actually produce minimal automata as of now - see #91.
 use super::{
@@ -10,8 +12,7 @@ use super::{
     state::StateAttributesBuilder,
     Automaton, NondeterministicAutomaton, State as DfaStateId, StateAttributes, StateTable,
 };
-use crate::{automaton::ArrayTransition, debug};
-use rsonpath_syntax::str::JsonString;
+use crate::{automaton::ArrayTransition, debug, string_pattern::StringPattern};
 use smallvec::{smallvec, SmallVec};
 use vector_map::VecMap;
 
@@ -31,9 +32,9 @@ pub(super) fn minimize(nfa: NondeterministicAutomaton) -> Result<Automaton, Comp
     minimizer.run()
 }
 
-pub(super) struct Minimizer<'q> {
+pub(super) struct Minimizer {
     /// The NFA being minimized.
-    nfa: NondeterministicAutomaton<'q>,
+    nfa: NondeterministicAutomaton,
     /// All superstates created thus far mapping to their index in the DFA being constructed.
     superstates: VecMap<SmallSet256, DfaStateId>,
     /// Map from superstates to the furthest reachable checkpoint on a path leading to that superstate.
@@ -41,15 +42,15 @@ pub(super) struct Minimizer<'q> {
     /// Superstates that have not been processed and expanded yet.
     active_superstates: SmallVec<[SmallSet256; 2]>,
     /// All superstates created thus far, in order matching the `superstates` map.
-    dfa_states: Vec<StateTable<'q>>,
+    dfa_states: Vec<StateTable>,
     /// Set of activated DFA states that are accepting.
     accepting: SmallSet256,
 }
 
 #[derive(Debug)]
-struct SuperstateTransitionTable<'q> {
+struct SuperstateTransitionTable {
     array: ArrayTransitionSet,
-    member: VecMap<&'q JsonString, SmallSet256>,
+    member: VecMap<Rc<StringPattern>, SmallSet256>,
     wildcard: SmallSet256,
 }
 
@@ -78,10 +79,10 @@ struct SuperstateTransitionTable<'q> {
  * Superstate number 0 is specifically designated as the rejecting state,
  * which is used when there is no available checkpoint to return to.
  **/
-impl<'q> Minimizer<'q> {
+impl Minimizer {
     /// Main loop of the algorithm. Initialize rejecting and initial states
     /// and perform expansion until we run out of active states.
-    fn run(mut self) -> Result<Automaton<'q>, CompilerError> {
+    fn run(mut self) -> Result<Automaton, CompilerError> {
         // Rejecting state has no outgoing transitions except for a self-loop.
         self.dfa_states.push(StateTable {
             array_transitions: smallvec![],
@@ -176,7 +177,7 @@ impl<'q> Minimizer<'q> {
         &self,
         id: DfaStateId,
         array_transitions: &[ArrayTransition],
-        member_transitions: &[(&JsonString, DfaStateId)],
+        member_transitions: &[(Rc<StringPattern>, DfaStateId)],
         fallback: DfaStateId,
     ) -> StateAttributes {
         let mut attrs = StateAttributesBuilder::new();
@@ -261,7 +262,7 @@ impl<'q> Minimizer<'q> {
         &self,
         current_superstate: SmallSet256,
         current_checkpoint: Option<NfaStateId>,
-    ) -> Result<SuperstateTransitionTable<'q>, CompilerError> {
+    ) -> Result<SuperstateTransitionTable, CompilerError> {
         let mut wildcard_targets = current_superstate
             .iter()
             .map(NfaStateId)
@@ -285,7 +286,7 @@ impl<'q> Minimizer<'q> {
         };
 
         for nfa_state in current_superstate.iter().map(NfaStateId) {
-            match self.nfa[nfa_state] {
+            match &self.nfa[nfa_state] {
                 // Direct states simply have a single transition to the next state in the NFA.
                 // Recursive transitions also have a self-loop, but that is handled by the
                 // checkpoints mechanism - here we only handle the forward transition.
@@ -293,17 +294,17 @@ impl<'q> Minimizer<'q> {
                 | NfaState::Recursive(nfa::Transition::Member(label)) => {
                     debug!(
                         "Considering member transition {nfa_state} --{}-> {}",
-                        label.unquoted(),
+                        std::str::from_utf8(label.unquoted()).unwrap_or("[invalid utf8]"),
                         nfa_state.next()?,
                     );
                     // Add the target NFA state to the target superstate, or create a singleton
                     // set if this is the first transition via this label encountered in the loop.
-                    if let Some(target) = transitions.member.get_mut(&label) {
+                    if let Some(target) = transitions.member.get_mut(label) {
                         target.insert(nfa_state.next()?.0);
                     } else {
                         let mut new_set = transitions.wildcard;
                         new_set.insert(nfa_state.next()?.0);
-                        transitions.member.insert(label, new_set);
+                        transitions.member.insert(label.clone(), new_set);
                     }
                 }
                 NfaState::Direct(nfa::Transition::Array(label))
@@ -336,7 +337,7 @@ impl<'q> Minimizer<'q> {
                     );
                     let mut new_set = transitions.wildcard;
                     new_set.insert(nfa_state.next()?.0);
-                    transitions.array.add_transition(label, new_set);
+                    transitions.array.add_transition(*label, new_set);
                 }
                 NfaState::Direct(nfa::Transition::Wildcard)
                 | NfaState::Recursive(nfa::Transition::Wildcard)
@@ -405,6 +406,7 @@ mod tests {
     use super::super::*;
     use super::*;
     use pretty_assertions::assert_eq;
+    use rsonpath_syntax::str::JsonString;
     use smallvec::smallvec;
 
     #[test]
@@ -552,16 +554,16 @@ mod tests {
     #[test]
     fn interstitial_descendant_wildcard() {
         // Query = $..a.b..*.a..b
-        let label_a = JsonString::new("a");
-        let label_b = JsonString::new("b");
+        let label_a = Rc::new(StringPattern::new(&JsonString::new("a")));
+        let label_b = Rc::new(StringPattern::new(&JsonString::new("b")));
 
         let nfa = NondeterministicAutomaton {
             ordered_states: vec![
-                NfaState::Recursive(nfa::Transition::Member(&label_a)),
-                NfaState::Direct(nfa::Transition::Member(&label_b)),
+                NfaState::Recursive(nfa::Transition::Member(label_a.clone())),
+                NfaState::Direct(nfa::Transition::Member(label_b.clone())),
                 NfaState::Recursive(nfa::Transition::Wildcard),
-                NfaState::Direct(nfa::Transition::Member(&label_a)),
-                NfaState::Recursive(nfa::Transition::Member(&label_b)),
+                NfaState::Direct(nfa::Transition::Member(label_a.clone())),
+                NfaState::Recursive(nfa::Transition::Member(label_b.clone())),
                 NfaState::Accepting,
             ],
         };
@@ -578,13 +580,13 @@ mod tests {
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_a, State(2))],
+                    member_transitions: smallvec![(label_a.clone(), State(2))],
                     fallback_state: State(1),
                     attributes: StateAttributes::EMPTY,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_a, State(2)), (&label_b, State(3))],
+                    member_transitions: smallvec![(label_a.clone(), State(2)), (label_b.clone(), State(3))],
                     fallback_state: State(1),
                     attributes: StateAttributes::EMPTY,
                 },
@@ -596,19 +598,19 @@ mod tests {
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_a, State(5))],
+                    member_transitions: smallvec![(label_a, State(5))],
                     fallback_state: State(4),
                     attributes: StateAttributes::EMPTY,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_b, State(6))],
+                    member_transitions: smallvec![(label_b.clone(), State(6))],
                     fallback_state: State(5),
                     attributes: StateAttributes::TRANSITIONS_TO_ACCEPTING,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_b, State(6))],
+                    member_transitions: smallvec![(label_b, State(6))],
                     fallback_state: State(5),
                     attributes: StateAttributes::ACCEPTING | StateAttributes::TRANSITIONS_TO_ACCEPTING,
                 },
@@ -621,16 +623,16 @@ mod tests {
     #[test]
     fn interstitial_nondescendant_wildcard() {
         // Query = $..a.b.*.a..b
-        let label_a = JsonString::new("a");
-        let label_b = JsonString::new("b");
+        let label_a = Rc::new(StringPattern::new(&JsonString::new("a")));
+        let label_b = Rc::new(StringPattern::new(&JsonString::new("b")));
 
         let nfa = NondeterministicAutomaton {
             ordered_states: vec![
-                NfaState::Recursive(nfa::Transition::Member(&label_a)),
-                NfaState::Direct(nfa::Transition::Member(&label_b)),
+                NfaState::Recursive(nfa::Transition::Member(label_a.clone())),
+                NfaState::Direct(nfa::Transition::Member(label_b.clone())),
                 NfaState::Direct(nfa::Transition::Wildcard),
-                NfaState::Direct(nfa::Transition::Member(&label_a)),
-                NfaState::Recursive(nfa::Transition::Member(&label_b)),
+                NfaState::Direct(nfa::Transition::Member(label_a.clone())),
+                NfaState::Recursive(nfa::Transition::Member(label_b.clone())),
                 NfaState::Accepting,
             ],
         };
@@ -647,43 +649,43 @@ mod tests {
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_a, State(2))],
+                    member_transitions: smallvec![(label_a.clone(), State(2))],
                     fallback_state: State(1),
                     attributes: StateAttributes::EMPTY,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_a, State(2)), (&label_b, State(3))],
+                    member_transitions: smallvec![(label_a.clone(), State(2)), (label_b.clone(), State(3))],
                     fallback_state: State(1),
                     attributes: StateAttributes::EMPTY,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_a, State(4))],
+                    member_transitions: smallvec![(label_a.clone(), State(4))],
                     fallback_state: State(7),
                     attributes: StateAttributes::EMPTY,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_a, State(5)), (&label_b, State(3))],
+                    member_transitions: smallvec![(label_a.clone(), State(5)), (label_b.clone(), State(3))],
                     fallback_state: State(1),
                     attributes: StateAttributes::EMPTY,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_b, State(6))],
+                    member_transitions: smallvec![(label_b.clone(), State(6))],
                     fallback_state: State(5),
                     attributes: StateAttributes::TRANSITIONS_TO_ACCEPTING,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_b, State(6))],
+                    member_transitions: smallvec![(label_b, State(6))],
                     fallback_state: State(5),
                     attributes: StateAttributes::ACCEPTING | StateAttributes::TRANSITIONS_TO_ACCEPTING,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_a, State(5))],
+                    member_transitions: smallvec![(label_a, State(5))],
                     fallback_state: State(1),
                     attributes: StateAttributes::EMPTY,
                 },
@@ -696,11 +698,11 @@ mod tests {
     #[test]
     fn simple_multi_accepting() {
         // Query = $..a.*
-        let label = JsonString::new("a");
+        let label = Rc::new(StringPattern::new(&JsonString::new("a")));
 
         let nfa = NondeterministicAutomaton {
             ordered_states: vec![
-                NfaState::Recursive(nfa::Transition::Member(&label)),
+                NfaState::Recursive(nfa::Transition::Member(label.clone())),
                 NfaState::Direct(nfa::Transition::Wildcard),
                 NfaState::Accepting,
             ],
@@ -718,25 +720,25 @@ mod tests {
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label, State(2)),],
+                    member_transitions: smallvec![(label.clone(), State(2)),],
                     fallback_state: State(1),
                     attributes: StateAttributes::EMPTY,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label, State(3))],
+                    member_transitions: smallvec![(label.clone(), State(3))],
                     fallback_state: State(4),
                     attributes: StateAttributes::TRANSITIONS_TO_ACCEPTING,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label, State(3))],
+                    member_transitions: smallvec![(label.clone(), State(3))],
                     fallback_state: State(4),
                     attributes: StateAttributes::ACCEPTING | StateAttributes::TRANSITIONS_TO_ACCEPTING,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label, State(2))],
+                    member_transitions: smallvec![(label, State(2))],
                     fallback_state: State(1),
                     attributes: StateAttributes::ACCEPTING,
                 },
@@ -794,11 +796,11 @@ mod tests {
     #[test]
     fn chained_wildcard_children() {
         // Query = $.a.*.*.*
-        let label = JsonString::new("a");
+        let label = Rc::new(StringPattern::new(&JsonString::new("a")));
 
         let nfa = NondeterministicAutomaton {
             ordered_states: vec![
-                NfaState::Direct(nfa::Transition::Member(&label)),
+                NfaState::Direct(nfa::Transition::Member(label.clone())),
                 NfaState::Direct(nfa::Transition::Wildcard),
                 NfaState::Direct(nfa::Transition::Wildcard),
                 NfaState::Direct(nfa::Transition::Wildcard),
@@ -818,7 +820,7 @@ mod tests {
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label, State(2))],
+                    member_transitions: smallvec![(label, State(2))],
                     fallback_state: State(0),
                     attributes: StateAttributes::UNITARY,
                 },
@@ -855,11 +857,11 @@ mod tests {
     #[test]
     fn chained_wildcard_children_after_descendant() {
         // Query = $..a.*.*
-        let label = JsonString::new("a");
+        let label = Rc::new(StringPattern::new(&JsonString::new("a")));
 
         let nfa = NondeterministicAutomaton {
             ordered_states: vec![
-                NfaState::Recursive(nfa::Transition::Member(&label)),
+                NfaState::Recursive(nfa::Transition::Member(label.clone())),
                 NfaState::Direct(nfa::Transition::Wildcard),
                 NfaState::Direct(nfa::Transition::Wildcard),
                 NfaState::Accepting,
@@ -878,49 +880,49 @@ mod tests {
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label, State(2))],
+                    member_transitions: smallvec![(label.clone(), State(2))],
                     fallback_state: State(1),
                     attributes: StateAttributes::EMPTY,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label, State(3))],
+                    member_transitions: smallvec![(label.clone(), State(3))],
                     fallback_state: State(7),
                     attributes: StateAttributes::EMPTY,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label, State(4))],
+                    member_transitions: smallvec![(label.clone(), State(4))],
                     fallback_state: State(5),
                     attributes: StateAttributes::TRANSITIONS_TO_ACCEPTING,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label, State(4))],
+                    member_transitions: smallvec![(label.clone(), State(4))],
                     fallback_state: State(5),
                     attributes: StateAttributes::ACCEPTING | StateAttributes::TRANSITIONS_TO_ACCEPTING,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label, State(6))],
+                    member_transitions: smallvec![(label.clone(), State(6))],
                     fallback_state: State(8),
                     attributes: StateAttributes::ACCEPTING | StateAttributes::TRANSITIONS_TO_ACCEPTING,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label, State(3))],
+                    member_transitions: smallvec![(label.clone(), State(3))],
                     fallback_state: State(7),
                     attributes: StateAttributes::ACCEPTING,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label, State(6))],
+                    member_transitions: smallvec![(label.clone(), State(6))],
                     fallback_state: State(8),
                     attributes: StateAttributes::TRANSITIONS_TO_ACCEPTING,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label, State(2))],
+                    member_transitions: smallvec![(label, State(2))],
                     fallback_state: State(1),
                     attributes: StateAttributes::ACCEPTING,
                 },
@@ -933,21 +935,21 @@ mod tests {
     #[test]
     fn child_and_descendant() {
         // Query = $.x..a.b.a.b.c..d
-        let label_a = JsonString::new("a");
-        let label_b = JsonString::new("b");
-        let label_c = JsonString::new("c");
-        let label_d = JsonString::new("d");
-        let label_x = JsonString::new("x");
+        let label_a = Rc::new(StringPattern::new(&JsonString::new("a")));
+        let label_b = Rc::new(StringPattern::new(&JsonString::new("b")));
+        let label_c = Rc::new(StringPattern::new(&JsonString::new("c")));
+        let label_d = Rc::new(StringPattern::new(&JsonString::new("d")));
+        let label_x = Rc::new(StringPattern::new(&JsonString::new("x")));
 
         let nfa = NondeterministicAutomaton {
             ordered_states: vec![
-                NfaState::Direct(nfa::Transition::Member(&label_x)),
-                NfaState::Recursive(nfa::Transition::Member(&label_a)),
-                NfaState::Direct(nfa::Transition::Member(&label_b)),
-                NfaState::Direct(nfa::Transition::Member(&label_a)),
-                NfaState::Direct(nfa::Transition::Member(&label_b)),
-                NfaState::Direct(nfa::Transition::Member(&label_c)),
-                NfaState::Recursive(nfa::Transition::Member(&label_d)),
+                NfaState::Direct(nfa::Transition::Member(label_x.clone())),
+                NfaState::Recursive(nfa::Transition::Member(label_a.clone())),
+                NfaState::Direct(nfa::Transition::Member(label_b.clone())),
+                NfaState::Direct(nfa::Transition::Member(label_a.clone())),
+                NfaState::Direct(nfa::Transition::Member(label_b.clone())),
+                NfaState::Direct(nfa::Transition::Member(label_c.clone())),
+                NfaState::Recursive(nfa::Transition::Member(label_d.clone())),
                 NfaState::Accepting,
             ],
         };
@@ -964,49 +966,49 @@ mod tests {
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_x, State(2))],
+                    member_transitions: smallvec![(label_x, State(2))],
                     fallback_state: State(0),
                     attributes: StateAttributes::UNITARY,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_a, State(3))],
+                    member_transitions: smallvec![(label_a.clone(), State(3))],
                     fallback_state: State(2),
                     attributes: StateAttributes::EMPTY,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_a, State(3)), (&label_b, State(4))],
+                    member_transitions: smallvec![(label_a.clone(), State(3)), (label_b.clone(), State(4))],
                     fallback_state: State(2),
                     attributes: StateAttributes::EMPTY,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_a, State(5))],
+                    member_transitions: smallvec![(label_a.clone(), State(5))],
                     fallback_state: State(2),
                     attributes: StateAttributes::EMPTY,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_a, State(3)), (&label_b, State(6))],
+                    member_transitions: smallvec![(label_a.clone(), State(3)), (label_b, State(6))],
                     fallback_state: State(2),
                     attributes: StateAttributes::EMPTY,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_a, State(5)), (&label_c, State(7))],
+                    member_transitions: smallvec![(label_a, State(5)), (label_c, State(7))],
                     fallback_state: State(2),
                     attributes: StateAttributes::EMPTY,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_d, State(8))],
+                    member_transitions: smallvec![(label_d.clone(), State(8))],
                     fallback_state: State(7),
                     attributes: StateAttributes::TRANSITIONS_TO_ACCEPTING,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_d, State(8))],
+                    member_transitions: smallvec![(label_d, State(8))],
                     fallback_state: State(7),
                     attributes: StateAttributes::ACCEPTING | StateAttributes::TRANSITIONS_TO_ACCEPTING,
                 },
@@ -1019,17 +1021,17 @@ mod tests {
     #[test]
     fn child_descendant_and_child_wildcard() {
         // Query = $.x.*..a.*.b
-        let label_a = JsonString::new("a");
-        let label_b = JsonString::new("b");
-        let label_x = JsonString::new("x");
+        let label_a = Rc::new(StringPattern::new(&JsonString::new("a")));
+        let label_b = Rc::new(StringPattern::new(&JsonString::new("b")));
+        let label_x = Rc::new(StringPattern::new(&JsonString::new("x")));
 
         let nfa = NondeterministicAutomaton {
             ordered_states: vec![
-                NfaState::Direct(nfa::Transition::Member(&label_x)),
+                NfaState::Direct(nfa::Transition::Member(label_x.clone())),
                 NfaState::Direct(nfa::Transition::Wildcard),
-                NfaState::Recursive(nfa::Transition::Member(&label_a)),
+                NfaState::Recursive(nfa::Transition::Member(label_a.clone())),
                 NfaState::Direct(nfa::Transition::Wildcard),
-                NfaState::Direct(nfa::Transition::Member(&label_b)),
+                NfaState::Direct(nfa::Transition::Member(label_b.clone())),
                 NfaState::Accepting,
             ],
         };
@@ -1046,7 +1048,7 @@ mod tests {
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_x, State(2))],
+                    member_transitions: smallvec![(label_x, State(2))],
                     fallback_state: State(0),
                     attributes: StateAttributes::UNITARY,
                 },
@@ -1058,37 +1060,37 @@ mod tests {
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_a, State(4))],
+                    member_transitions: smallvec![(label_a.clone(), State(4))],
                     fallback_state: State(3),
                     attributes: StateAttributes::EMPTY,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_a, State(5))],
+                    member_transitions: smallvec![(label_a.clone(), State(5))],
                     fallback_state: State(8),
                     attributes: StateAttributes::EMPTY,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_a, State(5)), (&label_b, State(6))],
+                    member_transitions: smallvec![(label_a.clone(), State(5)), (label_b.clone(), State(6))],
                     fallback_state: State(8),
                     attributes: StateAttributes::TRANSITIONS_TO_ACCEPTING,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_a, State(4)), (&label_b, State(7))],
+                    member_transitions: smallvec![(label_a.clone(), State(4)), (label_b.clone(), State(7))],
                     fallback_state: State(3),
                     attributes: StateAttributes::ACCEPTING | StateAttributes::TRANSITIONS_TO_ACCEPTING,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_a, State(4))],
+                    member_transitions: smallvec![(label_a.clone(), State(4))],
                     fallback_state: State(3),
                     attributes: StateAttributes::ACCEPTING,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_a, State(4)), (&label_b, State(7))],
+                    member_transitions: smallvec![(label_a, State(4)), (label_b, State(7))],
                     fallback_state: State(3),
                     attributes: StateAttributes::TRANSITIONS_TO_ACCEPTING,
                 },
@@ -1101,17 +1103,17 @@ mod tests {
     #[test]
     fn all_name_and_wildcard_selectors() {
         // Query = $.a.b..c..d.*..*
-        let label_a = JsonString::new("a");
-        let label_b = JsonString::new("b");
-        let label_c = JsonString::new("c");
-        let label_d = JsonString::new("d");
+        let label_a = Rc::new(StringPattern::new(&JsonString::new("a")));
+        let label_b = Rc::new(StringPattern::new(&JsonString::new("b")));
+        let label_c = Rc::new(StringPattern::new(&JsonString::new("c")));
+        let label_d = Rc::new(StringPattern::new(&JsonString::new("d")));
 
         let nfa = NondeterministicAutomaton {
             ordered_states: vec![
-                NfaState::Direct(nfa::Transition::Member(&label_a)),
-                NfaState::Direct(nfa::Transition::Member(&label_b)),
-                NfaState::Recursive(nfa::Transition::Member(&label_c)),
-                NfaState::Recursive(nfa::Transition::Member(&label_d)),
+                NfaState::Direct(nfa::Transition::Member(label_a.clone())),
+                NfaState::Direct(nfa::Transition::Member(label_b.clone())),
+                NfaState::Recursive(nfa::Transition::Member(label_c.clone())),
+                NfaState::Recursive(nfa::Transition::Member(label_d.clone())),
                 NfaState::Direct(nfa::Transition::Wildcard),
                 NfaState::Recursive(nfa::Transition::Wildcard),
                 NfaState::Accepting,
@@ -1127,31 +1129,31 @@ mod tests {
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_a, State(2)),],
+                    member_transitions: smallvec![(label_a, State(2)),],
                     fallback_state: State(0),
                     attributes: StateAttributes::UNITARY,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_b, State(3))],
+                    member_transitions: smallvec![(label_b, State(3))],
                     fallback_state: State(0),
                     attributes: StateAttributes::UNITARY,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_c, State(4))],
+                    member_transitions: smallvec![(label_c, State(4))],
                     fallback_state: State(3),
                     attributes: StateAttributes::EMPTY,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_d, State(5))],
+                    member_transitions: smallvec![(label_d.clone(), State(5))],
                     fallback_state: State(4),
                     attributes: StateAttributes::EMPTY,
                 },
                 StateTable {
                     array_transitions: smallvec![],
-                    member_transitions: smallvec![(&label_d, State(6))],
+                    member_transitions: smallvec![(label_d, State(6))],
                     fallback_state: State(6),
                     attributes: StateAttributes::EMPTY,
                 },

--- a/crates/rsonpath-lib/src/automaton/nfa.rs
+++ b/crates/rsonpath-lib/src/automaton/nfa.rs
@@ -1,40 +1,40 @@
 //! Definition of a nondeterministic automaton that can be directly
 //! obtained from a JsonPath query. This is then turned into
 //! a DFA with the minimizer.
-use crate::{automaton::SimpleSlice, error::UnsupportedFeatureError};
+use crate::{automaton::SimpleSlice, error::UnsupportedFeatureError, string_pattern::StringPattern};
 
 use super::{error::CompilerError, ArrayTransitionLabel};
 use rsonpath_syntax::{str::JsonString, JsonPathQuery, Step};
-use std::{fmt::Display, ops::Index};
+use std::{collections::HashMap, fmt::Display, ops::Index, rc::Rc};
 
 /// An NFA representing a query. It is always a directed path
 /// from an initial state to the unique accepting state at the end,
 /// where transitions are either self-loops or go forward to the immediate
 /// successor in the path.
 #[derive(Debug, PartialEq, Eq)]
-pub(super) struct NondeterministicAutomaton<'q> {
-    pub(super) ordered_states: Vec<NfaState<'q>>,
+pub(super) struct NondeterministicAutomaton {
+    pub(super) ordered_states: Vec<NfaState>,
 }
 
 /// Types of states allowed in an NFA directly mapped from a [`JsonPathQuery`].
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) enum NfaState<'q> {
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum NfaState {
     /// A state with a single forward [`Transition`] only.
-    Direct(Transition<'q>),
+    Direct(Transition),
     /// A state with a forward [`Transition`] and a wildcard self-loop.
-    Recursive(Transition<'q>),
+    Recursive(Transition),
     /// The final state in the NFA with no outgoing transitions.
     Accepting,
 }
 use NfaState::*;
 
 /// A transition in the NFA mapped from a [`JsonPathQuery`] selector.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) enum Transition<'q> {
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum Transition {
     /// A transition matching array indices.
     Array(ArrayTransitionLabel),
     /// A transition matching a specific member.
-    Member(&'q JsonString),
+    Member(Rc<StringPattern>),
     /// A transition matching anything.
     Wildcard,
 }
@@ -58,7 +58,7 @@ impl NfaStateId {
     }
 }
 
-impl<'q> NondeterministicAutomaton<'q> {
+impl NondeterministicAutomaton {
     /// Translate a [`JsonPathQuery`] into an NFA.
     ///
     /// # Errors
@@ -67,8 +67,11 @@ impl<'q> NondeterministicAutomaton<'q> {
     ///
     /// Returns a [`CompilerError::NotSupported`] if the query contains a construct
     /// not currently supported by rsonpath.
-    pub(super) fn new(query: &'q JsonPathQuery) -> Result<Self, CompilerError> {
+    pub(super) fn new<'q>(query: &'q JsonPathQuery) -> Result<Self, CompilerError> {
         use rsonpath_syntax::{Index, Selector};
+        use std::collections::hash_map::Entry;
+
+        let mut string_pattern_cache: HashMap<&'q JsonString, Rc<StringPattern>> = HashMap::new();
 
         let states_result: Result<Vec<NfaState>, CompilerError> = query
             .segments()
@@ -80,7 +83,17 @@ impl<'q> NondeterministicAutomaton<'q> {
                     Err(UnsupportedFeatureError::multiple_selectors().into())
                 } else {
                     let transition = match selectors.first() {
-                        Selector::Name(name) => Ok::<_, CompilerError>(Transition::Member(name)),
+                        Selector::Name(name) => {
+                            let pattern = match string_pattern_cache.entry(name) {
+                                Entry::Occupied(pat) => pat.get().clone(),
+                                Entry::Vacant(entry) => {
+                                    let pat = Rc::new(StringPattern::new(name));
+                                    entry.insert(pat.clone());
+                                    pat
+                                }
+                            };
+                            Ok::<_, CompilerError>(Transition::Member(pattern))
+                        }
                         Selector::Wildcard => Ok(Transition::Wildcard),
                         Selector::Index(Index::FromStart(index)) => Ok(Transition::Array((*index).into())),
                         Selector::Index(Index::FromEnd(_)) => Err(UnsupportedFeatureError::indexing_from_end().into()),
@@ -119,7 +132,7 @@ impl<'q> NondeterministicAutomaton<'q> {
         if let Err(err) = accepting_state {
             Err(CompilerError::QueryTooComplex(Some(err)))
         } else {
-            Ok(NondeterministicAutomaton { ordered_states: states })
+            Ok(Self { ordered_states: states })
         }
     }
 
@@ -129,8 +142,8 @@ impl<'q> NondeterministicAutomaton<'q> {
     }
 }
 
-impl<'q> Index<NfaStateId> for NondeterministicAutomaton<'q> {
-    type Output = NfaState<'q>;
+impl Index<NfaStateId> for NondeterministicAutomaton {
+    type Output = NfaState;
 
     fn index(&self, index: NfaStateId) -> &Self::Output {
         &self.ordered_states[index.0 as usize]
@@ -143,7 +156,7 @@ impl Display for NfaStateId {
     }
 }
 
-impl Display for NondeterministicAutomaton<'_> {
+impl Display for NondeterministicAutomaton {
     // This is the format for https://paperman.name/semigroup/
     // for easy debugging of minimization.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -152,7 +165,7 @@ impl Display for NondeterministicAutomaton<'_> {
             .iter()
             .filter_map(|s| match s {
                 Direct(Transition::Member(label)) | Recursive(Transition::Member(label)) => {
-                    Some(label.unquoted().to_string())
+                    Some(stringify_label(label).to_string())
                 }
                 Direct(Transition::Array(label)) | Recursive(Transition::Array(label)) => Some(label.to_string()),
                 _ => None,
@@ -165,7 +178,7 @@ impl Display for NondeterministicAutomaton<'_> {
                     writeln!(f, "s{i}.{} -> s{};", label, i + 1)?;
                 }
                 Direct(Transition::Member(label)) => {
-                    writeln!(f, "s{i}.{} -> s{};", label.unquoted(), i + 1)?;
+                    writeln!(f, "s{i}.{} -> s{};", stringify_label(label), i + 1)?;
                 }
                 Direct(Transition::Wildcard) => {
                     for label in &all_labels {
@@ -174,8 +187,8 @@ impl Display for NondeterministicAutomaton<'_> {
                     writeln!(f, "s{i}.X -> s{};", i + 1)?;
                 }
                 Recursive(Transition::Member(label)) => {
-                    writeln!(f, "s{i}.{} -> s{i}, s{};", label.unquoted(), i + 1)?;
-                    for label in all_labels.iter().filter(|&l| l != label.unquoted()) {
+                    writeln!(f, "s{i}.{} -> s{i}, s{};", stringify_label(label), i + 1)?;
+                    for label in all_labels.iter().filter(|&l| l != stringify_label(label)) {
                         writeln!(f, "s{i}.{} -> s{i};", label)?;
                     }
                     writeln!(f, "s{i}.X -> s{i};")?;
@@ -196,14 +209,18 @@ impl Display for NondeterministicAutomaton<'_> {
                 Accepting => (),
             }
         }
-        Ok(())
+        return Ok(());
+
+        fn stringify_label(label: &StringPattern) -> &str {
+            std::str::from_utf8(label.unquoted()).expect("labels must be valid utf8")
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rsonpath_syntax::builder::JsonPathQueryBuilder;
+    use rsonpath_syntax::{builder::JsonPathQueryBuilder, str::JsonString};
 
     #[test]
     fn nfa_test() {
@@ -225,10 +242,10 @@ mod tests {
 
         let expected_automaton = NondeterministicAutomaton {
             ordered_states: vec![
-                NfaState::Direct(Transition::Member(&label_a)),
-                NfaState::Direct(Transition::Member(&label_b)),
-                NfaState::Recursive(Transition::Member(&label_c)),
-                NfaState::Recursive(Transition::Member(&label_d)),
+                NfaState::Direct(Transition::Member(Rc::new(StringPattern::new(&label_a)))),
+                NfaState::Direct(Transition::Member(Rc::new(StringPattern::new(&label_b)))),
+                NfaState::Recursive(Transition::Member(Rc::new(StringPattern::new(&label_c)))),
+                NfaState::Recursive(Transition::Member(Rc::new(StringPattern::new(&label_d)))),
                 NfaState::Direct(Transition::Wildcard),
                 NfaState::Direct(Transition::Wildcard),
                 NfaState::Recursive(Transition::Wildcard),

--- a/crates/rsonpath-lib/src/classification/memmem.rs
+++ b/crates/rsonpath-lib/src/classification/memmem.rs
@@ -3,13 +3,13 @@
 use crate::{
     input::{error::InputError, Input},
     result::InputRecorder,
+    string_pattern::StringPattern,
     BLOCK_SIZE,
 };
-use rsonpath_syntax::str::JsonString;
 
 /// Classifier that can quickly find a member name in a byte stream.
 pub trait Memmem<'i, 'b, 'r, I: Input, const N: usize> {
-    /// Find a member key identified by a given [`JsonString`].
+    /// Find a member key identified by a given [`StringPattern`].
     ///
     /// - `first_block` &ndash; optional first block to search; if not provided,
     ///    the search will start at the next block returned by the underlying [`Input`] iterator.
@@ -22,7 +22,7 @@ pub trait Memmem<'i, 'b, 'r, I: Input, const N: usize> {
         &mut self,
         first_block: Option<I::Block<'i, N>>,
         start_idx: usize,
-        label: &JsonString,
+        label: &StringPattern,
     ) -> Result<Option<(usize, I::Block<'i, N>)>, InputError>;
 }
 

--- a/crates/rsonpath-lib/src/classification/memmem/avx2_32.rs
+++ b/crates/rsonpath-lib/src/classification/memmem/avx2_32.rs
@@ -51,7 +51,7 @@ where
     #[inline(always)]
     unsafe fn find_empty(
         &mut self,
-        label: &JsonString,
+        label: &StringPattern,
         mut offset: usize,
     ) -> Result<Option<(usize, I::Block<'i, SIZE>)>, InputError> {
         let classifier = vector_256::BlockClassifier256::new(b'"', b'"');
@@ -86,10 +86,10 @@ where
     #[inline(always)]
     unsafe fn find_letter(
         &mut self,
-        label: &JsonString,
+        label: &StringPattern,
         mut offset: usize,
     ) -> Result<Option<(usize, I::Block<'i, SIZE>)>, InputError> {
-        let classifier = vector_256::BlockClassifier256::new(label.unquoted().as_bytes()[0], b'"');
+        let classifier = vector_256::BlockClassifier256::new(label.unquoted()[0], b'"');
         let mut previous_block: u32 = 0;
 
         while let Some(block) = self.iter.next().e()? {
@@ -116,7 +116,7 @@ where
     #[inline(always)]
     unsafe fn find_label_avx2(
         &mut self,
-        label: &JsonString,
+        label: &StringPattern,
         mut offset: usize,
     ) -> Result<Option<(usize, I::Block<'i, SIZE>)>, InputError> {
         if label.unquoted().is_empty() {
@@ -125,8 +125,7 @@ where
             return self.find_letter(label, offset);
         }
 
-        let classifier =
-            vector_256::BlockClassifier256::new(label.unquoted().as_bytes()[0], label.unquoted().as_bytes()[1]);
+        let classifier = vector_256::BlockClassifier256::new(label.unquoted()[0], label.unquoted()[1]);
         let mut previous_block: u32 = 0;
 
         while let Some(block) = self.iter.next().e()? {
@@ -162,7 +161,7 @@ where
         &mut self,
         first_block: Option<I::Block<'i, SIZE>>,
         start_idx: usize,
-        label: &JsonString,
+        label: &StringPattern,
     ) -> Result<Option<(usize, I::Block<'i, SIZE>)>, InputError> {
         if let Some(b) = first_block {
             if let Some(res) = shared::find_label_in_first_block(self.input, b, start_idx, label)? {

--- a/crates/rsonpath-lib/src/classification/memmem/avx2_64.rs
+++ b/crates/rsonpath-lib/src/classification/memmem/avx2_64.rs
@@ -54,7 +54,7 @@ where
     #[inline(always)]
     unsafe fn find_empty(
         &mut self,
-        label: &JsonString,
+        label: &StringPattern,
         mut offset: usize,
     ) -> Result<Option<(usize, I::Block<'i, SIZE>)>, InputError> {
         let classifier = vector_256::BlockClassifier256::new(b'"', b'"');
@@ -94,10 +94,10 @@ where
     #[inline(always)]
     unsafe fn find_letter(
         &mut self,
-        label: &JsonString,
+        label: &StringPattern,
         mut offset: usize,
     ) -> Result<Option<(usize, I::Block<'i, SIZE>)>, InputError> {
-        let classifier = vector_256::BlockClassifier256::new(label.unquoted().as_bytes()[0], b'"');
+        let classifier = vector_256::BlockClassifier256::new(label.unquoted()[0], b'"');
         let mut previous_block: u64 = 0;
 
         while let Some(block) = self.iter.next().e()? {
@@ -124,7 +124,7 @@ where
     #[inline(always)]
     unsafe fn find_label_avx2(
         &mut self,
-        label: &JsonString,
+        label: &StringPattern,
         mut offset: usize,
     ) -> Result<Option<(usize, I::Block<'i, SIZE>)>, InputError> {
         if label.unquoted().is_empty() {
@@ -133,8 +133,7 @@ where
             return self.find_letter(label, offset);
         }
 
-        let classifier =
-            vector_256::BlockClassifier256::new(label.unquoted().as_bytes()[0], label.unquoted().as_bytes()[1]);
+        let classifier = vector_256::BlockClassifier256::new(label.unquoted()[0], label.unquoted()[1]);
         let mut previous_block: u64 = 0;
 
         while let Some(block) = self.iter.next().e()? {
@@ -170,7 +169,7 @@ where
         &mut self,
         first_block: Option<I::Block<'i, SIZE>>,
         start_idx: usize,
-        label: &JsonString,
+        label: &StringPattern,
     ) -> Result<Option<(usize, I::Block<'i, SIZE>)>, InputError> {
         if let Some(b) = first_block {
             if let Some(res) = shared::find_label_in_first_block(self.input, b, start_idx, label)? {

--- a/crates/rsonpath-lib/src/classification/memmem/nosimd.rs
+++ b/crates/rsonpath-lib/src/classification/memmem/nosimd.rs
@@ -42,14 +42,14 @@ where
     #[inline]
     fn find_label_sequential(
         &mut self,
-        label: &JsonString,
+        label: &StringPattern,
         mut offset: usize,
     ) -> Result<Option<(usize, I::Block<'i, N>)>, InputError> {
         let label_size = label.quoted().len();
         let first_c = if label.unquoted().is_empty() {
             b'"'
         } else {
-            label.unquoted().as_bytes()[0]
+            label.unquoted()[0]
         };
 
         while let Some(block) = self.iter.next().e()? {
@@ -78,7 +78,7 @@ where
         &mut self,
         first_block: Option<I::Block<'i, N>>,
         start_idx: usize,
-        label: &JsonString,
+        label: &StringPattern,
     ) -> Result<Option<(usize, I::Block<'i, N>)>, InputError> {
         if let Some(b) = first_block {
             if let Some(res) = shared::find_label_in_first_block(self.input, b, start_idx, label)? {

--- a/crates/rsonpath-lib/src/classification/memmem/shared.rs
+++ b/crates/rsonpath-lib/src/classification/memmem/shared.rs
@@ -1,8 +1,10 @@
-use crate::input::{
-    error::{InputError, InputErrorConvertible},
-    Input,
+use crate::{
+    input::{
+        error::{InputError, InputErrorConvertible},
+        Input,
+    },
+    string_pattern::StringPattern,
 };
-use rsonpath_syntax::str::JsonString;
 
 #[cfg(target_arch = "x86")]
 pub(super) mod mask_32;
@@ -17,7 +19,7 @@ pub(crate) fn find_label_in_first_block<'i, 'r, I, const N: usize>(
     input: &I,
     first_block: I::Block<'i, N>,
     start_idx: usize,
-    label: &JsonString,
+    label: &StringPattern,
 ) -> Result<Option<(usize, I::Block<'i, N>)>, InputError>
 where
     I: Input,

--- a/crates/rsonpath-lib/src/classification/memmem/shared/mask_32.rs
+++ b/crates/rsonpath-lib/src/classification/memmem/shared/mask_32.rs
@@ -1,5 +1,4 @@
 use crate::{
-    debug,
     input::{
         error::{InputError, InputErrorConvertible},
         Input,

--- a/crates/rsonpath-lib/src/classification/memmem/shared/mask_32.rs
+++ b/crates/rsonpath-lib/src/classification/memmem/shared/mask_32.rs
@@ -1,13 +1,16 @@
-use crate::input::{
-    error::{InputError, InputErrorConvertible},
-    Input,
+use crate::{
+    debug,
+    input::{
+        error::{InputError, InputErrorConvertible},
+        Input,
+    },
+    string_pattern::StringPattern,
 };
-use rsonpath_syntax::str::JsonString;
 
 #[inline(always)]
 pub(crate) fn find_in_mask<I: Input>(
     input: &I,
-    label: &JsonString,
+    label: &StringPattern,
     previous_block: u32,
     first: u32,
     second: u32,

--- a/crates/rsonpath-lib/src/classification/memmem/shared/mask_64.rs
+++ b/crates/rsonpath-lib/src/classification/memmem/shared/mask_64.rs
@@ -4,13 +4,13 @@ use crate::{
         error::{InputError, InputErrorConvertible},
         Input,
     },
+    string_pattern::StringPattern,
 };
-use rsonpath_syntax::str::JsonString;
 
 #[inline(always)]
 pub(crate) fn find_in_mask<I: Input>(
     input: &I,
-    label: &JsonString,
+    label: &StringPattern,
     previous_block: u64,
     first: u64,
     second: u64,

--- a/crates/rsonpath-lib/src/classification/memmem/sse2_32.rs
+++ b/crates/rsonpath-lib/src/classification/memmem/sse2_32.rs
@@ -54,7 +54,7 @@ where
     #[inline(always)]
     unsafe fn find_empty(
         &mut self,
-        label: &JsonString,
+        label: &StringPattern,
         mut offset: usize,
     ) -> Result<Option<(usize, I::Block<'i, SIZE>)>, InputError> {
         let classifier = vector_128::BlockClassifier128::new(b'"', b'"');
@@ -94,10 +94,10 @@ where
     #[inline(always)]
     unsafe fn find_letter(
         &mut self,
-        label: &JsonString,
+        label: &StringPattern,
         mut offset: usize,
     ) -> Result<Option<(usize, I::Block<'i, SIZE>)>, InputError> {
-        let classifier = vector_128::BlockClassifier128::new(label.unquoted().as_bytes()[0], b'"');
+        let classifier = vector_128::BlockClassifier128::new(label.unquoted()[0], b'"');
         let mut previous_block: u32 = 0;
 
         while let Some(block) = self.iter.next().e()? {
@@ -124,7 +124,7 @@ where
     #[inline(always)]
     unsafe fn find_label_sse2(
         &mut self,
-        label: &JsonString,
+        label: &StringPattern,
         mut offset: usize,
     ) -> Result<Option<(usize, I::Block<'i, SIZE>)>, InputError> {
         if label.unquoted().is_empty() {
@@ -133,8 +133,7 @@ where
             return self.find_letter(label, offset);
         }
 
-        let classifier =
-            vector_128::BlockClassifier128::new(label.unquoted().as_bytes()[0], label.unquoted().as_bytes()[1]);
+        let classifier = vector_128::BlockClassifier128::new(label.unquoted()[0], label.unquoted()[1]);
         let mut previous_block: u32 = 0;
 
         while let Some(block) = self.iter.next().e()? {
@@ -170,7 +169,7 @@ where
         &mut self,
         first_block: Option<I::Block<'i, SIZE>>,
         start_idx: usize,
-        label: &JsonString,
+        label: &StringPattern,
     ) -> Result<Option<(usize, I::Block<'i, SIZE>)>, InputError> {
         if let Some(b) = first_block {
             if let Some(res) = shared::find_label_in_first_block(self.input, b, start_idx, label)? {

--- a/crates/rsonpath-lib/src/classification/memmem/sse2_64.rs
+++ b/crates/rsonpath-lib/src/classification/memmem/sse2_64.rs
@@ -54,7 +54,7 @@ where
     #[inline(always)]
     unsafe fn find_empty(
         &mut self,
-        label: &JsonString,
+        label: &StringPattern,
         mut offset: usize,
     ) -> Result<Option<(usize, I::Block<'i, SIZE>)>, InputError> {
         let classifier = vector_128::BlockClassifier128::new(b'"', b'"');
@@ -106,10 +106,10 @@ where
     #[inline(always)]
     unsafe fn find_letter(
         &mut self,
-        label: &JsonString,
+        label: &StringPattern,
         mut offset: usize,
     ) -> Result<Option<(usize, I::Block<'i, SIZE>)>, InputError> {
-        let classifier = vector_128::BlockClassifier128::new(label.unquoted().as_bytes()[0], b'"');
+        let classifier = vector_128::BlockClassifier128::new(label.unquoted()[0], b'"');
         let mut previous_block: u64 = 0;
 
         while let Some(block) = self.iter.next().e()? {
@@ -148,7 +148,7 @@ where
     #[inline(always)]
     unsafe fn find_label_sse2(
         &mut self,
-        label: &JsonString,
+        label: &StringPattern,
         mut offset: usize,
     ) -> Result<Option<(usize, I::Block<'i, SIZE>)>, InputError> {
         if label.unquoted().is_empty() {
@@ -157,8 +157,7 @@ where
             return self.find_letter(label, offset);
         }
 
-        let classifier =
-            vector_128::BlockClassifier128::new(label.unquoted().as_bytes()[0], label.unquoted().as_bytes()[1]);
+        let classifier = vector_128::BlockClassifier128::new(label.unquoted()[0], label.unquoted()[1]);
         let mut previous_block: u64 = 0;
 
         while let Some(block) = self.iter.next().e()? {
@@ -206,7 +205,7 @@ where
         &mut self,
         first_block: Option<I::Block<'i, SIZE>>,
         start_idx: usize,
-        label: &JsonString,
+        label: &StringPattern,
     ) -> Result<Option<(usize, I::Block<'i, SIZE>)>, InputError> {
         if let Some(b) = first_block {
             if let Some(res) = shared::find_label_in_first_block(self.input, b, start_idx, label)? {

--- a/crates/rsonpath-lib/src/engine.rs
+++ b/crates/rsonpath-lib/src/engine.rs
@@ -101,15 +101,15 @@ pub trait Engine {
 pub trait Compiler {
     /// Concrete type of the [`Engines`](`Engine`) created,
     /// parameterized with the lifetime of the input query.
-    type E<'q>: Engine + 'q;
+    type E: Engine;
 
     /// Compile a [`JsonPathQuery`] into an [`Engine`].c
     ///
     /// # Errors
     /// An appropriate [`CompilerError`] is returned if the compiler
     /// cannot handle the query.
-    fn compile_query(query: &JsonPathQuery) -> Result<Self::E<'_>, CompilerError>;
+    fn compile_query(query: &JsonPathQuery) -> Result<Self::E, CompilerError>;
 
     /// Turn a compiled [`Automaton`] into an [`Engine`].
-    fn from_compiled_query(automaton: Automaton<'_>) -> Self::E<'_>;
+    fn from_compiled_query(automaton: Automaton) -> Self::E;
 }

--- a/crates/rsonpath-lib/src/engine/main.rs
+++ b/crates/rsonpath-lib/src/engine/main.rs
@@ -59,38 +59,39 @@ use crate::{
         approx_span::ApproxSpanRecorder, count::CountRecorder, index::IndexRecorder, nodes::NodesRecorder, Match,
         MatchCount, MatchIndex, MatchSpan, MatchedNodeType, Recorder, Sink,
     },
+    string_pattern::StringPattern,
     FallibleIterator, MaskType, BLOCK_SIZE,
 };
-use rsonpath_syntax::{num::JsonUInt, str::JsonString, JsonPathQuery};
+use rsonpath_syntax::{num::JsonUInt, JsonPathQuery};
 use smallvec::{smallvec, SmallVec};
 
 /// Main engine for a fixed JSONPath query.
 ///
 /// The engine is stateless, meaning that it can be executed
 /// on any number of separate inputs, even on separate threads.
-pub struct MainEngine<'q> {
-    automaton: Automaton<'q>,
+pub struct MainEngine {
+    automaton: Automaton,
     simd: SimdConfiguration,
 }
 
-impl Compiler for MainEngine<'_> {
-    type E<'q> = MainEngine<'q>;
+impl Compiler for MainEngine {
+    type E = Self;
 
     #[must_use = "compiling the query only creates an engine instance that should be used"]
     #[inline(always)]
-    fn compile_query(query: &JsonPathQuery) -> Result<MainEngine, CompilerError> {
+    fn compile_query(query: &JsonPathQuery) -> Result<Self, CompilerError> {
         let automaton = Automaton::new(query)?;
         debug!("DFA:\n {}", automaton);
         let simd = simd::configure();
         log::info!("SIMD configuration:\n {}", simd);
-        Ok(MainEngine { automaton, simd })
+        Ok(Self { automaton, simd })
     }
 
     #[inline(always)]
-    fn from_compiled_query(automaton: Automaton<'_>) -> Self::E<'_> {
+    fn from_compiled_query(automaton: Automaton) -> Self::E {
         let simd = simd::configure();
         log::info!("SIMD configuration:\n {}", simd);
-        MainEngine { automaton, simd }
+        Self { automaton, simd }
     }
 }
 
@@ -104,7 +105,7 @@ impl Compiler for MainEngine<'_> {
  * - we set up an appropriate Recorder impl for the result type.
  * - we configure SIMD and run the Executor in its context.
  */
-impl Engine for MainEngine<'_> {
+impl Engine for MainEngine {
     #[inline]
     fn count<I>(&self, input: &I) -> Result<MatchCount, EngineError>
     where
@@ -209,7 +210,7 @@ macro_rules! Classifier {
 }
 
 /// This is the heart of an Engine run that holds the entire execution state.
-struct Executor<'i, 'q, 'r, I, R, V> {
+struct Executor<'i, 'r, I, R, V> {
     /// Current depth in the JSON tree.
     depth: Depth,
     /// Current automaton state.
@@ -224,7 +225,7 @@ struct Executor<'i, 'q, 'r, I, R, V> {
     /// Execution stack.
     stack: SmallStack,
     /// Read-only access to the query automaton.
-    automaton: &'i Automaton<'q>,
+    automaton: &'i Automaton,
     /// Handle to the input.
     input: &'i I,
     /// Handle to the recorder.
@@ -234,12 +235,12 @@ struct Executor<'i, 'q, 'r, I, R, V> {
 }
 
 /// Initialize the [`Executor`] for the initial state of a query.
-fn query_executor<'i, 'q, 'r, I, R, V: Simd>(
-    automaton: &'i Automaton<'q>,
+fn query_executor<'i, 'r, I, R, V: Simd>(
+    automaton: &'i Automaton,
     input: &'i I,
     recorder: &'r R,
     simd: V,
-) -> Executor<'i, 'q, 'r, I, R, V>
+) -> Executor<'i, 'r, I, R, V>
 where
     I: Input,
     R: Recorder<I::Block<'i, BLOCK_SIZE>>,
@@ -258,7 +259,7 @@ where
     }
 }
 
-impl<'i, 'r, I, R, V> Executor<'i, '_, 'r, I, R, V>
+impl<'i, 'r, I, R, V> Executor<'i, 'r, I, R, V>
 where
     'i: 'r,
     I: Input,
@@ -295,7 +296,7 @@ where
     /// Once the perceived depth of the document goes to zero, this method terminates.
     fn run_on_subtree(&mut self, classifier: &mut Classifier!()) -> Result<(), EngineError> {
         dispatch_simd!(self.simd; self, classifier =>
-        fn<'i, 'q, 'r, I, R, V>(eng: &mut Executor<'i, 'q, 'r, I, R, V>, classifier: &mut Classifier!()) -> Result<(), EngineError>
+        fn<'i, 'r, I, R, V>(eng: &mut Executor<'i, 'r, I, R, V>, classifier: &mut Classifier!()) -> Result<(), EngineError>
         where
             'i: 'r,
             I: Input,
@@ -362,8 +363,8 @@ where
         // Look at accepting transitions and try to match them with the label.
         let mut any_matched = false;
 
-        for &(member_name, target) in self.automaton[self.state].member_transitions() {
-            if self.automaton.is_accepting(target) && self.is_match(idx, member_name)? {
+        for (member_name, target) in self.automaton[self.state].member_transitions() {
+            if self.automaton.is_accepting(*target) && self.is_match(idx, member_name.as_ref())? {
                 self.record_match_detected_at(idx + 1, NodeType::Atomic)?;
                 any_matched = true;
                 break;
@@ -470,12 +471,12 @@ where
         } else {
             let colon_idx = self.find_preceding_colon(idx);
 
-            for &(member_name, target) in self.automaton[self.state].member_transitions() {
+            for (member_name, target) in self.automaton[self.state].member_transitions() {
                 if let Some(colon_idx) = colon_idx {
-                    if self.is_match(colon_idx, member_name)? {
+                    if self.is_match(colon_idx, member_name.as_ref())? {
                         any_matched = true;
-                        self.transition_to(target, bracket_type);
-                        if self.automaton.is_accepting(target) {
+                        self.transition_to(*target, bracket_type);
+                        if self.automaton.is_accepting(*target) {
                             debug!("Accept {idx}");
                             self.record_match_detected_at(colon_idx + 1, NodeType::Complex(bracket_type))?;
                         }
@@ -653,7 +654,7 @@ where
 
     /// Check if the label ended with a colon at index `idx` matches the `member_name`.
     #[inline(always)]
-    fn is_match(&self, idx: usize, member_name: &JsonString) -> Result<bool, EngineError> {
+    fn is_match(&self, idx: usize, member_name: &StringPattern) -> Result<bool, EngineError> {
         let len = member_name.quoted().len();
 
         // The colon can be preceded by whitespace before the actual label.
@@ -751,7 +752,7 @@ impl SmallStack {
     }
 }
 
-impl<'i, 'r, I, R, V> CanHeadSkip<'i, 'r, I, R, V> for Executor<'i, '_, 'r, I, R, V>
+impl<'i, 'r, I, R, V> CanHeadSkip<'i, 'r, I, R, V> for Executor<'i, 'r, I, R, V>
 where
     I: Input,
     R: Recorder<I::Block<'i, BLOCK_SIZE>>,

--- a/crates/rsonpath-lib/src/input.rs
+++ b/crates/rsonpath-lib/src/input.rs
@@ -26,8 +26,7 @@ pub use mmap::MmapInput;
 pub use owned::OwnedBytes;
 
 use self::error::InputError;
-use crate::result::InputRecorder;
-use rsonpath_syntax::str::JsonString;
+use crate::{result::InputRecorder, string_pattern::StringPattern};
 use std::ops::Deref;
 
 /// Make the struct repr(C) with alignment equal to [`MAX_BLOCK_SIZE`].
@@ -151,7 +150,7 @@ pub trait Input: Sized {
     /// # Errors
     /// This function can read more data from the input if `to` falls beyond
     /// the range that was already read, and the read operation can fail.
-    fn is_member_match(&self, from: usize, to: usize, member: &JsonString) -> Result<bool, Self::Error>;
+    fn is_member_match(&self, from: usize, to: usize, member: &StringPattern) -> Result<bool, Self::Error>;
 }
 
 /// An iterator over blocks of input of size `N`.
@@ -211,7 +210,7 @@ impl<'i, const N: usize> InputBlock<'i, N> for &'i [u8] {
 }
 
 pub(super) trait SliceSeekable {
-    fn is_member_match(&self, from: usize, to: usize, member: &JsonString) -> bool;
+    fn is_member_match(&self, from: usize, to: usize, member: &StringPattern) -> bool;
 
     fn seek_backward(&self, from: usize, needle: u8) -> Option<usize>;
 

--- a/crates/rsonpath-lib/src/input/borrowed.rs
+++ b/crates/rsonpath-lib/src/input/borrowed.rs
@@ -18,8 +18,7 @@ use super::{
     padding::{EndPaddedInput, PaddedBlock, TwoSidesPaddedInput},
     Input, InputBlockIterator, SliceSeekable, MAX_BLOCK_SIZE,
 };
-use crate::{debug, result::InputRecorder};
-use rsonpath_syntax::str::JsonString;
+use crate::{debug, result::InputRecorder, string_pattern::StringPattern};
 
 /// Input wrapping a borrowed [`[u8]`] buffer.
 pub struct BorrowedBytes<'a> {
@@ -220,7 +219,7 @@ impl Input for BorrowedBytes<'_> {
     }
 
     #[inline(always)]
-    fn is_member_match(&self, from: usize, to: usize, member: &JsonString) -> Result<bool, Self::Error> {
+    fn is_member_match(&self, from: usize, to: usize, member: &StringPattern) -> Result<bool, Self::Error> {
         debug_assert!(from < to);
         // The hot path is when we're checking fully within the middle section.
         // This has to be as fast as possible, so the "cold" path referring to the TwoSidesPaddedInput
@@ -231,7 +230,7 @@ impl Input for BorrowedBytes<'_> {
             let from = from - MAX_BLOCK_SIZE;
             let to = to - MAX_BLOCK_SIZE;
             let slice = &bytes[from..to];
-            Ok(member.quoted().as_bytes() == slice && (from == 0 || bytes[from - 1] != b'\\'))
+            Ok(member.quoted() == slice && (from == 0 || bytes[from - 1] != b'\\'))
         } else {
             // This is a very expensive, cold path.
             Ok(self.as_padded_input().is_member_match(from, to, member))

--- a/crates/rsonpath-lib/src/input/buffered.rs
+++ b/crates/rsonpath-lib/src/input/buffered.rs
@@ -19,8 +19,7 @@
 use super::{
     error::InputError, repr_align_block_size, Input, InputBlock, InputBlockIterator, SliceSeekable, MAX_BLOCK_SIZE,
 };
-use crate::{error::InternalRsonpathError, result::InputRecorder, JSON_SPACE_BYTE};
-use rsonpath_syntax::str::JsonString;
+use crate::{error::InternalRsonpathError, result::InputRecorder, string_pattern::StringPattern, JSON_SPACE_BYTE};
 use std::{cell::RefCell, io::Read, ops::Deref, slice};
 
 // The buffer has to be a multiple of MAX_BLOCK_SIZE.
@@ -219,7 +218,7 @@ impl<R: Read> Input for BufferedInput<R> {
     }
 
     #[inline(always)]
-    fn is_member_match(&self, from: usize, to: usize, member: &JsonString) -> Result<bool, Self::Error> {
+    fn is_member_match(&self, from: usize, to: usize, member: &StringPattern) -> Result<bool, Self::Error> {
         let mut buf = self.0.borrow_mut();
 
         while buf.len() < to {
@@ -230,7 +229,7 @@ impl<R: Read> Input for BufferedInput<R> {
 
         let bytes = buf.as_slice();
         let slice = &bytes[from..to];
-        Ok(member.quoted().as_bytes() == slice && (from == 0 || bytes[from - 1] != b'\\'))
+        Ok(member.quoted() == slice && (from == 0 || bytes[from - 1] != b'\\'))
     }
 }
 

--- a/crates/rsonpath-lib/src/input/owned.rs
+++ b/crates/rsonpath-lib/src/input/owned.rs
@@ -24,8 +24,7 @@ use super::{
     padding::{PaddedBlock, TwoSidesPaddedInput},
     Input, SliceSeekable, MAX_BLOCK_SIZE,
 };
-use crate::result::InputRecorder;
-use rsonpath_syntax::str::JsonString;
+use crate::{result::InputRecorder, string_pattern::StringPattern};
 use std::borrow::Borrow;
 
 /// Input wrapping a buffer borrowable as a slice of bytes.
@@ -160,7 +159,7 @@ where
     }
 
     #[inline]
-    fn is_member_match(&self, from: usize, to: usize, member: &JsonString) -> Result<bool, Self::Error> {
+    fn is_member_match(&self, from: usize, to: usize, member: &StringPattern) -> Result<bool, Self::Error> {
         let offset = self.leading_padding_len();
         let Some(from) = from.checked_sub(offset) else {
             return Ok(false);

--- a/crates/rsonpath-lib/src/input/padding.rs
+++ b/crates/rsonpath-lib/src/input/padding.rs
@@ -1,6 +1,5 @@
 use super::{SliceSeekable, MAX_BLOCK_SIZE};
-use crate::JSON_SPACE_BYTE;
-use rsonpath_syntax::str::JsonString;
+use crate::{string_pattern::StringPattern, JSON_SPACE_BYTE};
 
 pub(super) struct PaddedBlock {
     bytes: [u8; MAX_BLOCK_SIZE],
@@ -102,9 +101,9 @@ impl SliceSeekable for EndPaddedInput<'_> {
 
     #[cold]
     #[inline(never)]
-    fn is_member_match(&self, from: usize, to: usize, member: &JsonString) -> bool {
+    fn is_member_match(&self, from: usize, to: usize, member: &StringPattern) -> bool {
         debug_assert!(from < to);
-        let other = member.quoted().as_bytes();
+        let other = member.quoted();
         self.cold_member_match(other, from, to)
     }
 }
@@ -160,9 +159,9 @@ impl SliceSeekable for TwoSidesPaddedInput<'_> {
 
     #[cold]
     #[inline(never)]
-    fn is_member_match(&self, from: usize, to: usize, member: &JsonString) -> bool {
+    fn is_member_match(&self, from: usize, to: usize, member: &StringPattern) -> bool {
         debug_assert!(from < to);
-        let other = member.quoted().as_bytes();
+        let other = member.quoted();
         self.cold_member_match(other, from, to)
     }
 }

--- a/crates/rsonpath-lib/src/input/slice.rs
+++ b/crates/rsonpath-lib/src/input/slice.rs
@@ -1,15 +1,15 @@
 use super::SliceSeekable;
-use rsonpath_syntax::str::JsonString;
+use crate::string_pattern::StringPattern;
 
 impl<T: AsRef<[u8]>> SliceSeekable for T {
-    fn is_member_match(&self, from: usize, to: usize, member: &JsonString) -> bool {
+    fn is_member_match(&self, from: usize, to: usize, member: &StringPattern) -> bool {
         let bytes = self.as_ref();
 
         if to > bytes.len() {
             return false;
         }
         let slice = &bytes[from..to];
-        member.quoted().as_bytes() == slice && (from == 0 || bytes[from - 1] != b'\\')
+        member.quoted() == slice && (from == 0 || bytes[from - 1] != b'\\')
     }
 
     fn seek_backward(&self, from: usize, needle: u8) -> Option<usize> {
@@ -310,6 +310,7 @@ mod tests {
 
     mod is_member_match {
         use crate::input::SliceSeekable;
+        use crate::string_pattern::StringPattern;
         use pretty_assertions::assert_eq;
         use rsonpath_syntax::str::JsonString;
 
@@ -317,7 +318,7 @@ mod tests {
         fn on_exact_match_returns_true() {
             let bytes = r#"{"needle":42,"other":37}"#.as_bytes();
 
-            let result = bytes.is_member_match(1, 9, &JsonString::new("needle"));
+            let result = bytes.is_member_match(1, 9, &StringPattern::new(&JsonString::new("needle")));
 
             assert_eq!(result, true);
         }
@@ -326,7 +327,7 @@ mod tests {
         fn matching_without_double_quotes_returns_false() {
             let bytes = r#"{"needle":42,"other":37}"#.as_bytes();
 
-            let result = bytes.is_member_match(2, 8, &JsonString::new("needle"));
+            let result = bytes.is_member_match(2, 8, &StringPattern::new(&JsonString::new("needle")));
 
             assert_eq!(result, false);
         }
@@ -335,7 +336,7 @@ mod tests {
         fn when_match_is_partial_due_to_escaped_double_quote_returns_false() {
             let bytes = r#"{"fake\"needle":42,"other":37}"#.as_bytes();
 
-            let result = bytes.is_member_match(7, 15, &JsonString::new("needle"));
+            let result = bytes.is_member_match(7, 15, &StringPattern::new(&JsonString::new("needle")));
 
             assert_eq!(result, false);
         }
@@ -345,7 +346,7 @@ mod tests {
         fn when_looking_for_string_with_escaped_double_quote_returns_true() {
             let bytes = r#"{"fake\"needle":42,"other":37}"#.as_bytes();
 
-            let result = bytes.is_member_match(1, 15, &JsonString::new(r#"fake"needle"#));
+            let result = bytes.is_member_match(1, 15, &StringPattern::new(&JsonString::new(r#"fake"needle"#)));
 
             assert_eq!(result, true);
         }

--- a/crates/rsonpath-lib/src/lib.rs
+++ b/crates/rsonpath-lib/src/lib.rs
@@ -197,6 +197,9 @@ pub mod engine;
 pub mod error;
 pub mod input;
 pub mod result;
+pub(crate) mod string_pattern;
+
+pub use string_pattern::StringPattern;
 
 cfg_if::cfg_if! {
     if #[cfg(target_pointer_width = "32")] {

--- a/crates/rsonpath-lib/src/string_pattern.rs
+++ b/crates/rsonpath-lib/src/string_pattern.rs
@@ -1,0 +1,74 @@
+use rsonpath_syntax::str::JsonString;
+
+/// String pattern coming from a JSONPath query that can be matched against strings in a JSON.
+///
+/// Right now the only pattern is matching against a given [`JsonString`].
+#[derive(Debug, Clone)]
+pub struct StringPattern(JsonString);
+
+impl std::hash::Hash for StringPattern {
+    #[inline]
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl PartialOrd for StringPattern {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.0.unquoted().cmp(other.0.unquoted()))
+    }
+}
+
+impl Ord for StringPattern {
+    #[inline]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.unquoted().cmp(other.0.unquoted())
+    }
+}
+
+impl PartialEq for StringPattern {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Eq for StringPattern {}
+
+impl StringPattern {
+    /// Get the underlying [`JsonString`] as bytes, including the delimiting double quote symbols.
+    #[inline]
+    #[must_use]
+    pub fn quoted(&self) -> &[u8] {
+        self.0.quoted().as_bytes()
+    }
+
+    /// Get the underlying [`JsonString`] as bytes, without the delimiting quotes.
+    #[inline]
+    #[must_use]
+    pub fn unquoted(&self) -> &[u8] {
+        self.0.unquoted().as_bytes()
+    }
+
+    /// Create a new pattern from a given [`JsonString`].
+    #[inline]
+    #[must_use]
+    pub fn new(string: &JsonString) -> Self {
+        Self(string.clone())
+    }
+}
+
+impl From<JsonString> for StringPattern {
+    #[inline(always)]
+    fn from(value: JsonString) -> Self {
+        Self::new(&value)
+    }
+}
+
+impl From<&JsonString> for StringPattern {
+    #[inline(always)]
+    fn from(value: &JsonString) -> Self {
+        Self::new(value)
+    }
+}

--- a/crates/rsonpath-lib/tests/input_implementation_tests.rs
+++ b/crates/rsonpath-lib/tests/input_implementation_tests.rs
@@ -2,8 +2,8 @@ use pretty_assertions::assert_eq;
 use rsonpath::{
     input::{error::InputError, *},
     result::empty::EmptyRecorder,
+    StringPattern,
 };
-use rsonpath_syntax::str::JsonString;
 use std::{cmp, fs, fs::File, io::Read, iter};
 use test_case::test_case;
 
@@ -143,7 +143,7 @@ impl InMemoryTestInput {
         }
     }
 
-    fn test_positive_is_member_match(&self, bytes: &[u8], from: usize, to: usize, json_string: JsonString) {
+    fn test_positive_is_member_match(&self, bytes: &[u8], from: usize, to: usize, json_string: StringPattern) {
         match self {
             InMemoryTestInput::Buffered => Self::test_positive_is_member_match_buffered(bytes, from, to, json_string),
             InMemoryTestInput::Borrowed => Self::test_positive_is_member_match_borrowed(bytes, from, to, json_string),
@@ -269,7 +269,7 @@ impl InMemoryTestInput {
         assert_eq!(result, Some((expected, expected_byte)));
     }
 
-    fn test_positive_is_member_match_buffered(bytes: &[u8], from: usize, to: usize, json_string: JsonString) {
+    fn test_positive_is_member_match_buffered(bytes: &[u8], from: usize, to: usize, json_string: StringPattern) {
         let input = create_buffered(bytes);
 
         let result = input.is_member_match(from, to, &json_string).expect("match succeeds");
@@ -278,7 +278,7 @@ impl InMemoryTestInput {
         assert!(result);
     }
 
-    fn test_positive_is_member_match_borrowed(bytes: &[u8], from: usize, to: usize, json_string: JsonString) {
+    fn test_positive_is_member_match_borrowed(bytes: &[u8], from: usize, to: usize, json_string: StringPattern) {
         let input = BorrowedBytes::new(bytes);
 
         // Need to take padding into account.
@@ -289,7 +289,7 @@ impl InMemoryTestInput {
         assert!(result);
     }
 
-    fn test_positive_is_member_match_owned(bytes: &[u8], from: usize, to: usize, json_string: JsonString) {
+    fn test_positive_is_member_match_owned(bytes: &[u8], from: usize, to: usize, json_string: StringPattern) {
         let input = OwnedBytes::new(bytes);
 
         // Need to take padding into account.
@@ -417,6 +417,7 @@ impl Read for ReadBytes<'_> {
 mod in_memory_proptests {
     use crate::InMemoryTestInput;
     use proptest::prelude::*;
+    use rsonpath::StringPattern;
     use rsonpath_syntax::str::JsonString;
     const JSON_WHITESPACE_BYTES: [u8; 4] = [b' ', b'\t', b'\n', b'\r'];
 
@@ -579,7 +580,7 @@ mod in_memory_proptests {
     prop_compose! {
         fn positive_is_member_match_strategy()
             (input in prop::collection::vec(prop::num::u8::ANY, 2..1024))
-            (mut from in 0..input.len(), mut to in 0..input.len(), mut input in Just(input)) -> (Vec<u8>, usize, usize, JsonString)
+            (mut from in 0..input.len(), mut to in 0..input.len(), mut input in Just(input)) -> (Vec<u8>, usize, usize, StringPattern)
         {
             if from > to {
                 std::mem::swap(&mut from, &mut to);
@@ -609,6 +610,7 @@ mod in_memory_proptests {
 
             let str = "x".repeat(to - from - 2);
             let json_string = JsonString::new(&str);
+            let pattern = StringPattern::new(&json_string);
             let slice = &mut input[from..to];
 
             slice.copy_from_slice(json_string.quoted().as_bytes());
@@ -617,7 +619,7 @@ mod in_memory_proptests {
                 input[from - 1] = 255;
             }
 
-            (input, from, to, json_string)
+            (input, from, to, pattern)
         }
     }
 }

--- a/crates/rsonpath/src/runner.rs
+++ b/crates/rsonpath/src/runner.rs
@@ -17,14 +17,14 @@ use std::{
     path::Path,
 };
 
-pub struct Runner<'q, S> {
-    pub with_compiled_query: Automaton<'q>,
+pub struct Runner<S> {
+    pub with_compiled_query: Automaton,
     pub with_engine: ResolvedEngine,
     pub with_input: ResolvedInput<S>,
     pub with_output: ResolvedOutput,
 }
 
-impl<S: AsRef<str>> Runner<'_, S> {
+impl<S: AsRef<str>> Runner<S> {
     pub fn run(self) -> Result<()> {
         match self.with_engine {
             ResolvedEngine::Main => {

--- a/fuzz/fuzz_targets/fuzz_arbitrary_bytes.rs
+++ b/fuzz/fuzz_targets/fuzz_arbitrary_bytes.rs
@@ -17,7 +17,7 @@ fuzz_target!(|data: DisplayableBytes| {
 #[derive(Arbitrary)]
 pub struct DisplayableBytes<'a>(&'a [u8]);
 
-impl<'a> Debug for DisplayableBytes<'a> {
+impl Debug for DisplayableBytes<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = String::from_utf8_lossy(self.0);
         f.debug_struct("Bytes")


### PR DESCRIPTION
## Short description

The `Automaton` struct borrowed the source query, which also caused the
Engine to carry the query's lifetime with it. The actual data being borrowed
were the `JsonString` values for member transitions.
In preparation for #117 we remove the borrowed `JsonString` and replace it
with `StringPattern`. For UTF-8 the `StringPattern` will be a more complex
struct that precomputes some stuff for efficient matching later.
For now, it's a thin wrapper over a `JsonString`.

During construction we may create many transitions over the same pattern.
To reduce the size of the automaton we cache the patterns and put them
into an `Rc`. This may get optimised later to instead use some kind of
inline storage, but it's unlikely to actually matter. I ran the benchmarks
and saw no measurable difference between the previous version and this one.

## Issue

Resolves: #613 

## Checklist

All of these should be ticked off before you submit the PR.

- [x] I ran `just verify` locally and it succeeded.
- [x] Issue was given <span style="color: #FF4400">go ahead</span> and is linked above **OR** I have included justification for a minor change.
- [x] Unit tests for my changes are included **OR** no functionality was changed.