### PR TITLE
Add feature 'multithread' to use Rsonpath in multithread context

### DIFF
--- a/crates/rsonpath-lib/Cargo.toml
+++ b/crates/rsonpath-lib/Cargo.toml
@@ -47,6 +47,7 @@ test-case = { workspace = true }
 default = ["simd"]
 arbitrary = ["dep:arbitrary"]
 simd = []
+multithread = []
 
 [[example]]
 name = "approx_spans_usage"

--- a/crates/rsonpath-lib/Cargo.toml
+++ b/crates/rsonpath-lib/Cargo.toml
@@ -47,7 +47,6 @@ test-case = { workspace = true }
 default = ["simd"]
 arbitrary = ["dep:arbitrary"]
 simd = []
-multithread = []
 
 [[example]]
 name = "approx_spans_usage"

--- a/crates/rsonpath-lib/src/automaton.rs
+++ b/crates/rsonpath-lib/src/automaton.rs
@@ -12,12 +12,7 @@ use crate::{automaton::error::CompilerError, debug, string_pattern::StringPatter
 use nfa::NondeterministicAutomaton;
 use rsonpath_syntax::{num::JsonUInt, JsonPathQuery};
 use smallvec::SmallVec;
-use std::{fmt::Display, ops::Index};
-
-#[cfg(not(feature = "multithread"))]
-use std::rc::Rc;
-#[cfg(feature = "multithread")]
-use std::sync::Arc as Rc;
+use std::{fmt::Display, ops::Index, sync::Arc};
 
 /// A minimal, deterministic automaton representing a JSONPath query.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -26,7 +21,7 @@ pub struct Automaton {
 }
 
 /// Transition when a JSON member name matches a [`StringPattern`].
-pub type MemberTransition = (Rc<StringPattern>, State);
+pub type MemberTransition = (Arc<StringPattern>, State);
 
 /// Transition on elements of an array with indices specified by either a single index
 /// or a simple slice expression.

--- a/crates/rsonpath-lib/src/automaton.rs
+++ b/crates/rsonpath-lib/src/automaton.rs
@@ -12,10 +12,15 @@ use crate::{automaton::error::CompilerError, debug, string_pattern::StringPatter
 use nfa::NondeterministicAutomaton;
 use rsonpath_syntax::{num::JsonUInt, JsonPathQuery};
 use smallvec::SmallVec;
-use std::{fmt::Display, ops::Index, rc::Rc};
+use std::{fmt::Display, ops::Index};
+
+#[cfg(not(feature = "multithread"))]
+use std::rc::Rc;
+#[cfg(feature = "multithread")]
+use std::sync::Arc as Rc;
 
 /// A minimal, deterministic automaton representing a JSONPath query.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Automaton {
     states: Vec<StateTable>,
 }
@@ -25,7 +30,7 @@ pub type MemberTransition = (Rc<StringPattern>, State);
 
 /// Transition on elements of an array with indices specified by either a single index
 /// or a simple slice expression.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ArrayTransition {
     label: ArrayTransitionLabel,
     target: State,
@@ -44,7 +49,7 @@ pub(super) enum ArrayTransitionLabel {
 ///
 /// Contains transitions triggered by matching member names or array indices, and a fallback transition
 /// triggered when none of the labelled transitions match.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct StateTable {
     attributes: StateAttributes,
     member_transitions: SmallVec<[MemberTransition; 2]>,

--- a/crates/rsonpath-lib/src/automaton/minimizer.rs
+++ b/crates/rsonpath-lib/src/automaton/minimizer.rs
@@ -1,9 +1,6 @@
 //! Determinization and minimization of an NFA into the final DFA used by the engines.
 
-#[cfg(not(feature = "multithread"))]
-use std::rc::Rc;
-#[cfg(feature = "multithread")]
-use std::sync::Arc as Rc;
+use std::sync::Arc;
 
 // NOTE: Some comments in this module are outdated, because the minimizer doesn't
 // actually produce minimal automata as of now - see #91.
@@ -53,7 +50,7 @@ pub(super) struct Minimizer {
 #[derive(Debug)]
 struct SuperstateTransitionTable {
     array: ArrayTransitionSet,
-    member: VecMap<Rc<StringPattern>, SmallSet256>,
+    member: VecMap<Arc<StringPattern>, SmallSet256>,
     wildcard: SmallSet256,
 }
 
@@ -180,7 +177,7 @@ impl Minimizer {
         &self,
         id: DfaStateId,
         array_transitions: &[ArrayTransition],
-        member_transitions: &[(Rc<StringPattern>, DfaStateId)],
+        member_transitions: &[(Arc<StringPattern>, DfaStateId)],
         fallback: DfaStateId,
     ) -> StateAttributes {
         let mut attrs = StateAttributesBuilder::new();
@@ -557,8 +554,8 @@ mod tests {
     #[test]
     fn interstitial_descendant_wildcard() {
         // Query = $..a.b..*.a..b
-        let label_a = Rc::new(StringPattern::new(&JsonString::new("a")));
-        let label_b = Rc::new(StringPattern::new(&JsonString::new("b")));
+        let label_a = Arc::new(StringPattern::new(&JsonString::new("a")));
+        let label_b = Arc::new(StringPattern::new(&JsonString::new("b")));
 
         let nfa = NondeterministicAutomaton {
             ordered_states: vec![
@@ -626,8 +623,8 @@ mod tests {
     #[test]
     fn interstitial_nondescendant_wildcard() {
         // Query = $..a.b.*.a..b
-        let label_a = Rc::new(StringPattern::new(&JsonString::new("a")));
-        let label_b = Rc::new(StringPattern::new(&JsonString::new("b")));
+        let label_a = Arc::new(StringPattern::new(&JsonString::new("a")));
+        let label_b = Arc::new(StringPattern::new(&JsonString::new("b")));
 
         let nfa = NondeterministicAutomaton {
             ordered_states: vec![
@@ -701,7 +698,7 @@ mod tests {
     #[test]
     fn simple_multi_accepting() {
         // Query = $..a.*
-        let label = Rc::new(StringPattern::new(&JsonString::new("a")));
+        let label = Arc::new(StringPattern::new(&JsonString::new("a")));
 
         let nfa = NondeterministicAutomaton {
             ordered_states: vec![
@@ -799,7 +796,7 @@ mod tests {
     #[test]
     fn chained_wildcard_children() {
         // Query = $.a.*.*.*
-        let label = Rc::new(StringPattern::new(&JsonString::new("a")));
+        let label = Arc::new(StringPattern::new(&JsonString::new("a")));
 
         let nfa = NondeterministicAutomaton {
             ordered_states: vec![
@@ -860,7 +857,7 @@ mod tests {
     #[test]
     fn chained_wildcard_children_after_descendant() {
         // Query = $..a.*.*
-        let label = Rc::new(StringPattern::new(&JsonString::new("a")));
+        let label = Arc::new(StringPattern::new(&JsonString::new("a")));
 
         let nfa = NondeterministicAutomaton {
             ordered_states: vec![
@@ -938,11 +935,11 @@ mod tests {
     #[test]
     fn child_and_descendant() {
         // Query = $.x..a.b.a.b.c..d
-        let label_a = Rc::new(StringPattern::new(&JsonString::new("a")));
-        let label_b = Rc::new(StringPattern::new(&JsonString::new("b")));
-        let label_c = Rc::new(StringPattern::new(&JsonString::new("c")));
-        let label_d = Rc::new(StringPattern::new(&JsonString::new("d")));
-        let label_x = Rc::new(StringPattern::new(&JsonString::new("x")));
+        let label_a = Arc::new(StringPattern::new(&JsonString::new("a")));
+        let label_b = Arc::new(StringPattern::new(&JsonString::new("b")));
+        let label_c = Arc::new(StringPattern::new(&JsonString::new("c")));
+        let label_d = Arc::new(StringPattern::new(&JsonString::new("d")));
+        let label_x = Arc::new(StringPattern::new(&JsonString::new("x")));
 
         let nfa = NondeterministicAutomaton {
             ordered_states: vec![
@@ -1024,9 +1021,9 @@ mod tests {
     #[test]
     fn child_descendant_and_child_wildcard() {
         // Query = $.x.*..a.*.b
-        let label_a = Rc::new(StringPattern::new(&JsonString::new("a")));
-        let label_b = Rc::new(StringPattern::new(&JsonString::new("b")));
-        let label_x = Rc::new(StringPattern::new(&JsonString::new("x")));
+        let label_a = Arc::new(StringPattern::new(&JsonString::new("a")));
+        let label_b = Arc::new(StringPattern::new(&JsonString::new("b")));
+        let label_x = Arc::new(StringPattern::new(&JsonString::new("x")));
 
         let nfa = NondeterministicAutomaton {
             ordered_states: vec![
@@ -1106,10 +1103,10 @@ mod tests {
     #[test]
     fn all_name_and_wildcard_selectors() {
         // Query = $.a.b..c..d.*..*
-        let label_a = Rc::new(StringPattern::new(&JsonString::new("a")));
-        let label_b = Rc::new(StringPattern::new(&JsonString::new("b")));
-        let label_c = Rc::new(StringPattern::new(&JsonString::new("c")));
-        let label_d = Rc::new(StringPattern::new(&JsonString::new("d")));
+        let label_a = Arc::new(StringPattern::new(&JsonString::new("a")));
+        let label_b = Arc::new(StringPattern::new(&JsonString::new("b")));
+        let label_c = Arc::new(StringPattern::new(&JsonString::new("c")));
+        let label_d = Arc::new(StringPattern::new(&JsonString::new("d")));
 
         let nfa = NondeterministicAutomaton {
             ordered_states: vec![

--- a/crates/rsonpath-lib/src/automaton/minimizer.rs
+++ b/crates/rsonpath-lib/src/automaton/minimizer.rs
@@ -1,6 +1,9 @@
 //! Determinization and minimization of an NFA into the final DFA used by the engines.
 
+#[cfg(not(feature = "multithread"))]
 use std::rc::Rc;
+#[cfg(feature = "multithread")]
+use std::sync::Arc as Rc;
 
 // NOTE: Some comments in this module are outdated, because the minimizer doesn't
 // actually produce minimal automata as of now - see #91.

--- a/crates/rsonpath-lib/src/automaton/nfa.rs
+++ b/crates/rsonpath-lib/src/automaton/nfa.rs
@@ -5,7 +5,12 @@ use crate::{automaton::SimpleSlice, error::UnsupportedFeatureError, string_patte
 
 use super::{error::CompilerError, ArrayTransitionLabel};
 use rsonpath_syntax::{str::JsonString, JsonPathQuery, Step};
-use std::{collections::HashMap, fmt::Display, ops::Index, rc::Rc};
+use std::{collections::HashMap, fmt::Display, ops::Index};
+
+#[cfg(not(feature = "multithread"))]
+use std::rc::Rc;
+#[cfg(feature = "multithread")]
+use std::sync::Arc as Rc;
 
 /// An NFA representing a query. It is always a directed path
 /// from an initial state to the unique accepting state at the end,

--- a/crates/rsonpath-lib/src/engine/head_skipping.rs
+++ b/crates/rsonpath-lib/src/engine/head_skipping.rs
@@ -1,7 +1,11 @@
 //! Engine decorator that performs **head skipping** &ndash; an extremely optimized search for
 //! the first matching member name in a query starting with a self-looping state.
 //! This happens in queries starting with a descendant selector.
+
+#[cfg(not(feature = "multithread"))]
 use std::rc::Rc;
+#[cfg(feature = "multithread")]
+use std::sync::Arc as Rc;
 
 use crate::{
     automaton::{Automaton, State},

--- a/crates/rsonpath-lib/src/engine/head_skipping.rs
+++ b/crates/rsonpath-lib/src/engine/head_skipping.rs
@@ -2,10 +2,7 @@
 //! the first matching member name in a query starting with a self-looping state.
 //! This happens in queries starting with a descendant selector.
 
-#[cfg(not(feature = "multithread"))]
-use std::rc::Rc;
-#[cfg(feature = "multithread")]
-use std::sync::Arc as Rc;
+use std::sync::Arc;
 
 use crate::{
     automaton::{Automaton, State},
@@ -71,7 +68,7 @@ pub(super) struct HeadSkip<'b, I, V, const N: usize> {
     bytes: &'b I,
     state: State,
     is_accepting: bool,
-    member_name: Rc<StringPattern>,
+    member_name: Arc<StringPattern>,
     simd: V,
 }
 

--- a/crates/rsonpath-lib/src/engine/main.rs
+++ b/crates/rsonpath-lib/src/engine/main.rs
@@ -76,6 +76,8 @@ pub struct MainEngine {
     simd: SimdConfiguration,
 }
 
+static_assertions::assert_impl_all!(MainEngine: Send, Sync);
+
 impl Compiler for MainEngine {
     type E = Self;
 

--- a/crates/rsonpath-lib/src/engine/main.rs
+++ b/crates/rsonpath-lib/src/engine/main.rs
@@ -69,6 +69,7 @@ use smallvec::{smallvec, SmallVec};
 ///
 /// The engine is stateless, meaning that it can be executed
 /// on any number of separate inputs, even on separate threads.
+#[derive(Clone)]
 pub struct MainEngine {
     automaton: Automaton,
     simd: SimdConfiguration,


### PR DESCRIPTION
## Short description

Improve the change from #618 to instead use `Arc` references and make `MainEngine` both `Sync` and `Send` again. 

## Issue

Resolves: #620

## Checklist

All of these should be ticked off before you submit the PR.

- [x] I ran `just verify` locally and it succeeded.
- [x] Issue was given <span style="color: #FF4400">go ahead</span> and is linked above **OR** I have included justification for a minor change.
- [x] Unit tests for my changes are included **OR** no functionality was changed.