### PR TITLE
V0ldek/nom 8.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/*
 /.vscode/*.log
+/.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,12 +934,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,12 +944,11 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.3"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
- "minimal-lexical",
 ]
 
 [[package]]

--- a/crates/rsonpath-benchmarks/Cargo.toml
+++ b/crates/rsonpath-benchmarks/Cargo.toml
@@ -52,6 +52,7 @@ memchr = "2.7.4"
 [features]
 default = ["simd"]
 simd = ["rsonpath-lib/simd"]
+jsurfer = []
 
 [build-dependencies]
 eyre = "0.6.12"

--- a/crates/rsonpath-benchmarks/build.rs
+++ b/crates/rsonpath-benchmarks/build.rs
@@ -3,7 +3,9 @@ use std::error::Error;
 use std::process::Command;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    setup_jsurfer()?;
+    if cfg!(feature = "jsurfer") {
+        setup_jsurfer()?;
+    }
 
     Ok(())
 }

--- a/crates/rsonpath-lib/src/automaton.rs
+++ b/crates/rsonpath-lib/src/automaton.rs
@@ -139,7 +139,6 @@ impl ArrayTransitionLabel {
 }
 
 impl From<JsonUInt> for ArrayTransitionLabel {
-    #[must_use]
     #[inline(always)]
     fn from(index: JsonUInt) -> Self {
         Self::Index(index)
@@ -147,7 +146,6 @@ impl From<JsonUInt> for ArrayTransitionLabel {
 }
 
 impl From<SimpleSlice> for ArrayTransitionLabel {
-    #[must_use]
     #[inline(always)]
     fn from(slice: SimpleSlice) -> Self {
         Self::Slice(slice)

--- a/crates/rsonpath-lib/src/automaton/minimizer.rs
+++ b/crates/rsonpath-lib/src/automaton/minimizer.rs
@@ -63,7 +63,7 @@ struct SuperstateTransitionTable {
  *   2. Each superstate containing
  *      a) a checkpoint and;
  *      b) some states on the path from the initial state to that checkpoint,
- *         is equivalent to a superstate without the b) states.
+ *      is equivalent to a superstate without the b) states.
  *
  * This allows on-the-fly minimization with the `normalize` function, vastly reducing
  * the number of superstates to consider.

--- a/crates/rsonpath-lib/src/classification/memmem.rs
+++ b/crates/rsonpath-lib/src/classification/memmem.rs
@@ -12,9 +12,9 @@ pub trait Memmem<'i, 'b, 'r, I: Input, const N: usize> {
     /// Find a member key identified by a given [`StringPattern`].
     ///
     /// - `first_block` &ndash; optional first block to search; if not provided,
-    ///    the search will start at the next block returned by the underlying [`Input`] iterator.
+    ///   the search will start at the next block returned by the underlying [`Input`] iterator.
     /// - `start_idx` &ndash; index of the start of search, either falling inside `first_block`,
-    ///    or at the start of the next block.
+    ///   or at the start of the next block.
     ///
     /// # Errors
     /// Errors when reading the underlying [`Input`] are propagated.

--- a/crates/rsonpath-lib/src/engine.rs
+++ b/crates/rsonpath-lib/src/engine.rs
@@ -110,6 +110,7 @@ pub trait Compiler {
     /// # Errors
     /// An appropriate [`CompilerError`] is returned if the compiler
     /// cannot handle the query.
+    #[must_use = "compiling the query only creates an engine instance that should be used"]
     fn compile_query(query: &JsonPathQuery) -> Result<Self::E, CompilerError>;
 
     /// Turn a compiled [`Automaton`] into an [`Engine`].

--- a/crates/rsonpath-lib/src/engine/main.rs
+++ b/crates/rsonpath-lib/src/engine/main.rs
@@ -89,7 +89,6 @@ impl MainEngine {
 impl Compiler for MainEngine {
     type E = Self;
 
-    #[must_use = "compiling the query only creates an engine instance that should be used"]
     #[inline(always)]
     fn compile_query(query: &JsonPathQuery) -> Result<Self, CompilerError> {
         let automaton = Automaton::new(query)?;

--- a/crates/rsonpath-lib/src/input/mmap.rs
+++ b/crates/rsonpath-lib/src/input/mmap.rs
@@ -5,9 +5,9 @@
 //! 1. Your platform supports memory maps.
 //! 2. The input data is in a file or comes from standard input:
 //!    a) if from a file, then you can guarantee that the file is not going to be modified
-//!       in or out of process while the input is alive;
+//!    in or out of process while the input is alive;
 //!    b) if from stdin, then that the input lives in memory (for example comes via a pipe);
-//!       input from a tty is not memory-mappable.
+//!    input from a tty is not memory-mappable.
 //!
 //! ## Performance characteristics
 //!

--- a/crates/rsonpath-syntax/Cargo.toml
+++ b/crates/rsonpath-syntax/Cargo.toml
@@ -20,7 +20,7 @@ all-features = true
 [dependencies]
 arbitrary = { workspace = true, features = ["derive"], optional = true }
 owo-colors = { version = "4.1.0", default-features = false, optional = true }
-nom = "7.1.3"
+nom = "8.0.0"
 serde = { workspace = true, optional = true, features = ["derive"] }
 thiserror = { workspace = true }
 unicode-width = "0.2.0"

--- a/crates/rsonpath-syntax/src/builder.rs
+++ b/crates/rsonpath-syntax/src/builder.rs
@@ -480,7 +480,6 @@ impl SliceBuilder {
 
 impl From<SliceBuilder> for Slice {
     #[inline]
-    #[must_use]
     fn from(mut value: SliceBuilder) -> Self {
         value.to_slice()
     }
@@ -495,7 +494,6 @@ impl Default for SliceBuilder {
     /// assert_eq!(Slice::default(), slice);
     /// ```
     #[inline(always)]
-    #[must_use]
     fn default() -> Self {
         Self::new()
     }
@@ -575,7 +573,6 @@ impl Default for SingularJsonPathQueryBuilder {
 
 impl From<SingularJsonPathQueryBuilder> for SingularJsonPathQuery {
     #[inline]
-    #[must_use]
     fn from(value: SingularJsonPathQueryBuilder) -> Self {
         Self {
             segments: value.segments,


### PR DESCRIPTION
## Short description

There was a bunch of breaking changes in nom 8.0.0.  Nom's maintainers claim it reduces code generated by parsers, which is always worth it.

It actually seems to improve performance by roughly 10%  on compiling small queries. On larger queries the cost of compilation
outweighs the cost of parsing so it's not noticable.

## Checklist

All of these should be ticked off before you submit the PR.

- [x] I ran `just verify` locally and it succeeded.
- [x] Issue was given <span style="color: #FF4400">go ahead</span> and is linked above **OR** I have included justification for a minor change.
- [x] Unit tests for my changes are included **OR** no functionality was changed.