### PR TITLE
V0ldek/paste fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,9 +1083,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -1118,9 +1118,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -1746,9 +1746,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1767,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
  "serde",
@@ -2095,9 +2095,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]

--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ We have a paper on `rsonpath` to be published at [ASPLOS '24](https://www.asplos
 This project was conceived as [my thesis](/pdf/fast-execution-of-jsonpath-queries.pdf). You can read it for details on the theoretical
 background on the engine and details of its implementation.
 
+We also have a short talk from ASPLOS 2024 about rsonpath!
+
+https://gienieczko.com/asplos-2024-talk.mp4
+
+(excuse the audio quality, the sound in the source video was corrupted and we had to salvage)
+
 ## Dependencies
 
 Showing direct dependencies, for full graph see below.

--- a/deny.toml
+++ b/deny.toml
@@ -46,6 +46,7 @@ no-default-features = false
 # If set, these feature will be enabled when collecting metadata. If `--features`
 # is specified on the cmd line they will take precedence over this option.
 #features = []
+exclude-dev = true
 
 [output]
 # When outputting inclusion graphs in diagnostics that include features, this


### PR DESCRIPTION
## Short description

Remove dev deps from cargo deny.

This is specifically to fix deny failing due to `rmp` relying on unmaintained `paste`. We don't really care about dev-deps, there's a lot of them and e.g. `rmp` only exists for a handful of serde tests in `rsonpath-syntax`.

Added a link to the ASPLOS 24 rsonpath talk as a little treat.

## Checklist

All of these should be ticked off before you submit the PR.

- [x] I ran `just verify` locally and it succeeded.
- [x] Issue was given <span style="color: #FF4400">go ahead</span> and is linked above **OR** I have included justification for a minor change.
- [x] Unit tests for my changes are included **OR** no functionality was changed.