### PR TITLE
ci: use github hosted ARM runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
         with:
           submodules: true
       - name: Install lld (Unix)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm'
         run: sudo apt install lld
       - name: Install Rust toolchain (stable)
         uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0 # stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           - x86_64-pc-windows-msvc
           - x86_64-unknown-linux-gnu
         include:
-          - os: [self-hosted, linux, ARM64]
+          - os: ubuntu-24.04-arm
             target_triple: aarch64-unknown-linux-gnu
             rustflags: "-C link-arg=-fuse-ld=lld --deny warnings"
           - os: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,7 +39,7 @@ jobs:
           - x86_64-pc-windows-msvc
           - x86_64-unknown-linux-gnu
         include:
-          - os: [self-hosted, linux, ARM64]
+          - os: ubuntu-24.04-arm
             target_triple:
               aarch64-unknown-linux-gnu
             rustflags: "-C link-arg=-fuse-ld=lld --deny warnings"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -113,7 +113,7 @@ jobs:
         if: matrix.prologue-script != ''
         run: ${{ matrix.prologue-script }}
       - name: Install lld (Unix)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm'
         run: sudo apt install lld
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Short description

GitHub added support for linux ARM runners a few months ago. These are most likely more efficient than our self-hosted one, so let's try to use them.

## Checklist

All of these should be ticked off before you submit the PR.

- [x] I ran `just verify` locally and it succeeded.
- [x] ~~Issue was given <span style="color: #FF4400">go ahead</span> and is linked above **OR**~~ I have included justification for a minor change.
- [x] ~~Unit tests for my changes are included **OR**~~ no functionality was changed.