### PR TITLE
fix: skipping inside arrays on comma-atomic

### DIFF
--- a/crates/rsonpath-benchmarks/Cargo.toml
+++ b/crates/rsonpath-benchmarks/Cargo.toml
@@ -21,13 +21,13 @@ name = "pathimpl"
 [dependencies]
 clap = { version = "4.5.23", features = ["derive", "wrap_help"] }
 color-eyre = { version = "0.6.3", default-features = false }
-criterion = "0.6.0"
+criterion = "0.7.0"
 eyre = "0.6.12"
 flate2 = "1.0.35"
 hex-literal = "1.0.0"
 indicatif = "0.18.0"
 jni = { version = "0.21.1", features = ["invocation", "default"] }
-jsonpath-rust = "1.0.0"
+jsonpath-rust = "1.0.4"
 lazy_static = "1.5.0"
 serde_json = "1.0.134"
 sha2 = "0.10.8"

--- a/crates/rsonpath-benchmarks/src/framework.rs
+++ b/crates/rsonpath-benchmarks/src/framework.rs
@@ -329,7 +329,7 @@ impl<I: Implementation> BenchFn for PreparedQuery<I> {
         };
 
         let result = self.implementation.run(q, f).unwrap();
-        criterion::black_box(result);
+        std::hint::black_box(result);
     }
 }
 

--- a/crates/rsonpath-benchmarks/src/main.rs
+++ b/crates/rsonpath-benchmarks/src/main.rs
@@ -23,7 +23,7 @@ fn run<I: Implementation>(imp: I, query_str: &str, path_str: &str) -> Result<()>
 
     let result = imp.run(&query, &file)?;
 
-    println!("{}", result);
+    println!("{result}");
 
     Ok(())
 }

--- a/crates/rsonpath-lib/src/classification/structural/nosimd.rs
+++ b/crates/rsonpath-lib/src/classification/structural/nosimd.rs
@@ -121,15 +121,13 @@ where
     #[inline]
     fn reclassify(&mut self, idx: usize) {
         if let Some(block) = self.block.take() {
+            let relative_idx = idx + 1 - self.iter.get_offset();
             let quote_classified_block = block.quote_classified;
-            let relevant_idx = idx + 1;
-            let block_idx = (idx + 1) % N;
-            debug!("relevant_idx is {relevant_idx}.");
-
-            if block_idx != 0 || relevant_idx == self.iter.get_offset() {
+            debug!("relative_idx is {relative_idx}.");
+            if relative_idx < 64 {
                 let new_block = Block::from_idx(
                     quote_classified_block,
-                    block_idx,
+                    relative_idx,
                     self.are_colons_on,
                     self.are_commas_on,
                 );

--- a/crates/rsonpath-lib/src/classification/structural/nosimd.rs
+++ b/crates/rsonpath-lib/src/classification/structural/nosimd.rs
@@ -124,7 +124,7 @@ where
             let relative_idx = idx + 1 - self.iter.get_offset();
             let quote_classified_block = block.quote_classified;
             debug!("relative_idx is {relative_idx}.");
-            if relative_idx < 64 {
+            if relative_idx < N {
                 let new_block = Block::from_idx(
                     quote_classified_block,
                     relative_idx,

--- a/crates/rsonpath-lib/src/classification/structural/shared.rs
+++ b/crates/rsonpath-lib/src/classification/structural/shared.rs
@@ -62,7 +62,7 @@ macro_rules! structural_classifier {
                     let quote_classified_block = block.quote_classified;
                     debug!("relative_idx is {relative_idx}.");
 
-                    if relative_idx < 64 {
+                    if relative_idx < $size {
                         debug!("need to reclassify.");
 
                         let mask = <$mask_ty>::MAX << relative_idx;

--- a/crates/rsonpath-lib/src/classification/structural/shared.rs
+++ b/crates/rsonpath-lib/src/classification/structural/shared.rs
@@ -58,15 +58,14 @@ macro_rules! structural_classifier {
             #[inline]
             fn reclassify(&mut self, idx: usize) {
                 if let Some(block) = self.block.take() {
+                    let relative_idx = idx + 1 - self.iter.get_offset();
                     let quote_classified_block = block.quote_classified;
-                    let relevant_idx = idx + 1;
-                    let block_idx = (idx + 1) % $size;
-                    debug!("relevant_idx is {relevant_idx}.");
+                    debug!("relative_idx is {relative_idx}.");
 
-                    if block_idx != 0 || relevant_idx == self.iter.get_offset() {
+                    if relative_idx < 64 {
                         debug!("need to reclassify.");
 
-                        let mask = <$mask_ty>::MAX << block_idx;
+                        let mask = <$mask_ty>::MAX << relative_idx;
                         // SAFETY: target_feature invariant
                         let mut new_block = unsafe { self.classifier.classify(quote_classified_block) };
                         new_block.structural_mask &= mask;

--- a/crates/rsonpath-lib/src/engine.rs
+++ b/crates/rsonpath-lib/src/engine.rs
@@ -42,7 +42,7 @@ pub trait Engine {
     /// Find the starting indices of matches on the given [`Input`] and write them to the [`Sink`].
     ///
     /// The result is equivalent to using [`matches`](Engine::matches) and extracting the
-    /// [`Match::span.start_idx`],
+    /// [`Match::span`] and [`MatchSpan::start_idx`],
     /// but in general is much more time and memory efficient.
     ///
     /// # Errors

--- a/crates/rsonpath-test/Cargo.toml
+++ b/crates/rsonpath-test/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-rsonpath-lib = { workspace = true }
+rsonpath-lib = { workspace = true, features = ["simd"] }
 rsonpath-syntax = { workspace = true }
 
 [build-dependencies]


### PR DESCRIPTION
## Short description

Tail skipping was not triggered when the item matching the unitary transition was an atomic value inside a list. For example, selecting `$[0]` from a long list of integers would never skip, massively degrading performance.

Skipping was added to `handle_comma` in the same vein as it was in `handle_colon` to enable this.

## Issue

Resolves: #751

## Checklist

All of these should be ticked off before you submit the PR.

- [x] I ran `just verify` locally and it succeeded.
- [x] Issue was given <span style="color: #FF4400">go ahead</span> and is linked above **OR** I have included justification for a minor change.
- [x] Unit tests for my changes are included **OR** no functionality was changed.