### PR TITLE
fix: fix panic in specific cases of reclassification at end of file

### DIFF
--- a/crates/rsonpath-lib/src/classification/depth/shared.rs
+++ b/crates/rsonpath-lib/src/classification/depth/shared.rs
@@ -52,16 +52,12 @@ macro_rules! depth_classifier {
 
             #[inline(always)]
             fn stop(self, block: Option<Self::Block>) -> ResumeClassifierState<'a, I, Q, $mask_ty, $size> {
-                let block_state = block.and_then(|b| {
+                let block_state = block.map(|b| {
                     let idx = b.idx;
                     debug!("Depth iterator stopping at index {idx}");
-                    if idx >= b.quote_classified.len() {
-                        None
-                    } else {
-                        Some(ResumeClassifierBlockState {
-                            block: b.quote_classified,
-                            idx,
-                        })
+                    ResumeClassifierBlockState {
+                        block: b.quote_classified,
+                        idx,
                     }
                 });
 

--- a/crates/rsonpath-lib/src/engine/tail_skipping.rs
+++ b/crates/rsonpath-lib/src/engine/tail_skipping.rs
@@ -95,7 +95,7 @@ where
                 debug!("Skipping complete, resuming structural classification.");
                 let resume_state = depth_classifier.stop(current_vector);
                 debug!("Finished at {}", resume_state.get_idx());
-                idx = resume_state.get_idx();
+                idx = resume_state.get_idx() - 1;
                 tail_skip.simd.resume_structural_classification(resume_state)
             });
 

--- a/crates/rsonpath-test/documents/toml/reclassification.toml
+++ b/crates/rsonpath-test/documents/toml/reclassification.toml
@@ -1,0 +1,50 @@
+# Define the JSON input for all query test cases.
+[input]
+# Short description of the input structure.
+description = "Nested lists and objects to stress structural reclassification logic."
+# Set to true only if your specific test input is fully compressed (no extraneous whitespace).
+is_compressed = false
+
+# Inline JSON document.
+[input.source]
+json_string = '''
+[
+  {
+    "x": [
+      {
+        "id": 1
+      }
+    ]
+  },
+  {
+    "x": [
+      {
+        "id": 2
+      }
+    ]
+  },
+  {
+    "x": [
+      {
+        "id": 3
+      }]}]
+'''
+
+# Define queries to test on the input.
+[[queries]]
+# Valid JSONPath query string.
+query = "$[:2].x[*].id"
+# Short descritpion of the query semantics.
+description = "select a slice from the top and then dig into structure of all children"
+
+[queries.results]
+# Number of expected matches.
+count = 2
+# Byte locations of spans of all matches, in order.
+spans = [[39, 40], [97, 98]]
+# Stringified values of all matches, verbatim as in the input,
+# in the same order as above.
+nodes = [
+    '1',
+    '2',
+]


### PR DESCRIPTION
## Short description

A particular combination of reclassification after tail-skipping at the very end of the file could cause a panic if the file-ending closing occurred directly after the skipped-to character.

The root cause was that the depth-skipping code returned the byte index one *after* the skipped-to character, which would then cause the structural classifier to consider that position in the mask to be irrelevant and zero it out during reclassification.

This commit adds a test case that reproduces the issue and then fixes the off-by-one error.

## Issue

Minor bug fix.

## Checklist

All of these should be ticked off before you submit the PR.

- [x] I ran `just verify` locally and it succeeded.
- [x] Issue was given <span style="color: #FF4400">go ahead</span> and is linked above **OR** I have included justification for a minor change.
- [x] Unit tests for my changes are included **OR** no functionality was changed.