### PR TITLE
 fuzz: rework structural fuzzing to have explicit limits

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -3,4 +3,3 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool
 COPY . $SRC/rsonpath
 WORKDIR $SRC/rsonpath
 COPY .clusterfuzzlite/build.sh $SRC/
-ENV FUZZER_ARGS="-rss_limit_mb=8192 -timeout=30"

--- a/.github/workflows/clusterfuzzlite-batch.yml
+++ b/.github/workflows/clusterfuzzlite-batch.yml
@@ -5,7 +5,7 @@ on:
       fuzz-seconds:
         description: 'Total time to fuzz, in seconds'
         required: true
-        default: '2700'
+        default: '4800'
         type: string
   schedule:
     - cron: '0 3 * * *'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,15 +83,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,17 +379,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
-]
-
-[[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1210,7 +1190,6 @@ dependencies = [
 name = "rsonpath-syntax"
 version = "0.4.0"
 dependencies = [
- "arbitrary",
  "ciborium",
  "insta",
  "nom",

--- a/crates/rsonpath-syntax-proptest/src/lib.rs
+++ b/crates/rsonpath-syntax-proptest/src/lib.rs
@@ -16,21 +16,33 @@
 //!     }
 //! }
 //! ```
+
 use proptest::{option, prelude::*, strategy};
 use rsonpath_syntax::{
     builder::SliceBuilder, num::JsonInt, str::JsonString, JsonPathQuery, LogicalExpr, Segment, Selector, Selectors,
 };
+use std::fmt::Debug;
 
 /// A valid JSONPath string and the [`JsonPathQuery`] object parsed from it.
 ///
 /// This is the struct through which an [`proptest::arbitrary::Arbitrary`] implementation
 /// for [`JsonPathQuery`] is provided.
-#[derive(Debug)]
 pub struct ArbitraryJsonPathQuery {
     /// The JSONPath query string.
     pub string: String,
     /// The parsed JSONPath query.
     pub parsed: JsonPathQuery,
+}
+
+impl Debug for ArbitraryJsonPathQuery {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ArbitraryJsonPathQuery")
+            .field("string", &self.string)
+            .field("parsed", &self.parsed)
+            .field("string_raw", &self.string.as_bytes())
+            .finish()
+    }
 }
 
 /// Parameters of the [`ArbitraryJsonPathQuery`] [`Arbitrary`](`proptest::arbitrary::Arbitrary`) implementation.

--- a/crates/rsonpath-syntax/Cargo.toml
+++ b/crates/rsonpath-syntax/Cargo.toml
@@ -18,7 +18,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 all-features = true
 
 [dependencies]
-arbitrary = { workspace = true, features = ["derive"], optional = true }
 owo-colors = { version = "4.2.3", default-features = false, optional = true }
 nom = "8.0.0"
 serde = { workspace = true, optional = true, features = ["derive"] }
@@ -37,7 +36,6 @@ test-case = { workspace = true }
 
 [features]
 default = []
-arbitrary = ["dep:arbitrary"]
 color = ["dep:owo-colors"]
 serde = ["dep:serde"]
 

--- a/crates/rsonpath-syntax/src/builder.rs
+++ b/crates/rsonpath-syntax/src/builder.rs
@@ -240,6 +240,7 @@ impl JsonPathSelectorsBuilder {
     }
 
     fn build(self) -> Selectors {
+        assert!(!self.selectors.is_empty());
         Selectors::many(self.selectors)
     }
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -148,7 +148,6 @@ dependencies = [
 name = "rsonpath-syntax"
 version = "0.4.0"
 dependencies = [
- "arbitrary",
  "nom",
  "thiserror",
  "unicode-width",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -18,7 +18,6 @@ path = "../crates/rsonpath-lib"
 
 [dependencies.rsonpath-syntax]
 path = "../crates/rsonpath-syntax"
-features = ["arbitrary"]
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/fuzz/fuzz_targets/query_fuzz_round_trip.rs
+++ b/fuzz/fuzz_targets/query_fuzz_round_trip.rs
@@ -1,15 +1,13 @@
 //! Fuzz round-tripping - for every valid query parsing its `.to_string()` should give an equivalent query.
 #![no_main]
 
-use libfuzzer_sys::{fuzz_target, Corpus};
-use rsonpath_syntax::JsonPathQuery;
+use libfuzzer_sys::fuzz_target;
+use rsonpath_lib_fuzz::ArbitraryJsonPathQuery;
 
-fuzz_target!(|data: JsonPathQuery| -> Corpus {
-    let str = data.to_string();
+fuzz_target!(|data: ArbitraryJsonPathQuery| {
+    let str = data.0.to_string();
     match rsonpath_syntax::parse(&str) {
-        Ok(query) => assert_eq!(data, query, "query string: {str}"),
-        Err(err) if err.is_nesting_limit_exceeded() => return Corpus::Reject,
+        Ok(query) => assert_eq!(data.0, query, "query string: {str}"),
         Err(_) => panic!("expected parse to succeed"),
     }
-    Corpus::Keep
 });

--- a/fuzz/src/json.rs
+++ b/fuzz/src/json.rs
@@ -1,0 +1,95 @@
+use arbitrary::{Arbitrary, Unstructured};
+use std::collections::HashMap;
+use std::fmt::Display;
+
+#[derive(Debug)]
+pub struct ArbitraryJson<const MAX_SIZE: usize>(serde_json::Value);
+
+impl<const MAX_SIZE: usize> Display for ArbitraryJson<MAX_SIZE> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<'a, const MAX_SIZE: usize> Arbitrary<'a> for ArbitraryJson<MAX_SIZE> {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        enum RawValue {
+            Leaf(LeafValue),
+            Nested(NestedValue),
+        }
+
+        #[derive(Arbitrary)]
+        enum LeafValue {
+            Null,
+            Bool(bool),
+            Integer(i64),
+            Float(f64),
+            String(String),
+        }
+
+        enum NestedValue {
+            Array(Vec<RawValue>),
+            Object(HashMap<String, RawValue>),
+        }
+
+        impl From<RawValue> for serde_json::Value {
+            fn from(value: RawValue) -> Self {
+                match value {
+                    RawValue::Leaf(LeafValue::Null) => serde_json::Value::Null,
+                    RawValue::Leaf(LeafValue::Bool(b)) => serde_json::Value::Bool(b),
+                    RawValue::Leaf(LeafValue::Integer(n)) => serde_json::Value::from(n),
+                    RawValue::Leaf(LeafValue::Float(f)) => serde_json::Value::from(f),
+                    RawValue::Leaf(LeafValue::String(s)) => serde_json::Value::String(s),
+                    RawValue::Nested(NestedValue::Array(arr)) => {
+                        serde_json::Value::Array(arr.into_iter().map(|x| x.into()).collect())
+                    }
+                    RawValue::Nested(NestedValue::Object(obj)) => {
+                        serde_json::Value::Object(obj.into_iter().map(|x| (x.0, x.1.into())).collect())
+                    }
+                }
+            }
+        }
+
+        fn generate_json_with_size(u: &mut Unstructured, size: usize) -> arbitrary::Result<RawValue> {
+            if size == 1 && u.arbitrary::<bool>()? {
+                Ok(RawValue::Leaf(u.arbitrary::<LeafValue>()?))
+            } else {
+                let mut rem_size = size - 1;
+                if u.arbitrary::<bool>()? {
+                    // Array.
+                    let mut nested_values = vec![];
+                    while rem_size > 0 {
+                        let nested_size = u.int_in_range(1..=rem_size)?;
+                        rem_size -= nested_size;
+                        nested_values.push(generate_json_with_size(u, nested_size)?);
+                    }
+                    Ok(RawValue::Nested(NestedValue::Array(nested_values)))
+                } else {
+                    // Object.
+                    // We generate arbitrary labels and values.
+                    // We can't guarantee Unstructured won't start returning the same repeat label at some point.
+                    // In that case, we most likely ran out of bytes in the source. We apply a "good-enough-effort"
+                    // strategy - append the index number to the end of the label, insert it, if it overwrites something
+                    // then too bad.
+                    let mut object = HashMap::new();
+                    let mut i = 0;
+                    while rem_size > 0 {
+                        let nested_size = u.int_in_range(1..=rem_size)?;
+                        rem_size -= nested_size;
+                        let value = generate_json_with_size(u, nested_size)?;
+                        let mut key = u.arbitrary::<String>()?;
+                        if object.contains_key(&key) {
+                            key += &i.to_string();
+                        }
+                        object.insert(key, value);
+                        i += 1;
+                    }
+                    Ok(RawValue::Nested(NestedValue::Object(object)))
+                }
+            }
+        }
+
+        let size = u.int_in_range(1..=MAX_SIZE)?;
+        Ok(ArbitraryJson(generate_json_with_size(u, size)?.into()))
+    }
+}

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,0 +1,5 @@
+mod json;
+mod query;
+
+pub use json::ArbitraryJson;
+pub use query::{ArbitraryJsonPathQuery, ArbitraryJsonString, ArbitraryJsonUInt, ArbitrarySupportedQuery};

--- a/fuzz/src/query.rs
+++ b/fuzz/src/query.rs
@@ -1,0 +1,377 @@
+use arbitrary::{Arbitrary, Unstructured};
+use rsonpath_syntax::builder::{
+    EmptyComparisonExprBuilder, EmptyLogicalExprBuilder, JsonPathQueryBuilder, JsonPathSelectorsBuilder,
+    LogicalExprBuilder, SingularJsonPathQueryBuilder, SliceBuilder,
+};
+use rsonpath_syntax::num::{JsonFloat, JsonInt, JsonNumber, JsonUInt};
+use rsonpath_syntax::prelude::JsonString;
+use rsonpath_syntax::{ComparisonExpr, JsonPathQuery, Literal};
+
+struct SafeUnstructured<'a, 'b> {
+    u: &'b mut Unstructured<'a>,
+    error: Option<arbitrary::Error>,
+}
+
+impl<'a, 'b> SafeUnstructured<'a, 'b> {
+    fn new(u: &'b mut Unstructured<'a>) -> Self {
+        Self { u, error: None }
+    }
+
+    fn err_or<T>(self, t: T) -> arbitrary::Result<T> {
+        if let Some(err) = self.error {
+            Err(err)
+        } else {
+            Ok(t)
+        }
+    }
+
+    fn access<F, T: Default>(&mut self, f: F) -> T
+    where
+        F: FnOnce(&mut Unstructured<'a>) -> arbitrary::Result<T>,
+    {
+        match f(self.u) {
+            Ok(x) => x,
+            Err(err) => {
+                self.error = Some(err);
+                T::default()
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ArbitrarySupportedQuery(pub JsonPathQuery);
+
+#[derive(Debug, Arbitrary)]
+enum SupportedSegment {
+    Child(SupportedSelector),
+    Descendant(SupportedSelector),
+}
+
+#[derive(Debug, Arbitrary)]
+enum SupportedSelector {
+    Name(ArbitraryJsonString),
+    Wildcard,
+    Index(ArbitraryJsonUInt),
+}
+
+impl<'a> Arbitrary<'a> for ArbitrarySupportedQuery {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let segment_count = u.arbitrary_len::<SupportedSegment>()?;
+        let mut query = JsonPathQueryBuilder::new();
+
+        for _ in 0..segment_count {
+            let segment = u.arbitrary::<SupportedSegment>()?;
+            match segment {
+                SupportedSegment::Child(SupportedSelector::Name(name)) => query.child_name(name.0),
+                SupportedSegment::Child(SupportedSelector::Wildcard) => query.child_wildcard(),
+                SupportedSegment::Child(SupportedSelector::Index(idx)) => query.child_index(idx.0),
+                SupportedSegment::Descendant(SupportedSelector::Name(name)) => query.descendant_name(name.0),
+                SupportedSegment::Descendant(SupportedSelector::Wildcard) => query.descendant_wildcard(),
+                SupportedSegment::Descendant(SupportedSelector::Index(idx)) => query.descendant_index(idx.0),
+            };
+        }
+
+        Ok(ArbitrarySupportedQuery(query.into()))
+    }
+}
+
+#[derive(Debug)]
+pub struct ArbitraryJsonPathQuery(pub JsonPathQuery);
+#[derive(Debug)]
+pub struct ArbitraryJsonString(pub JsonString);
+#[derive(Debug)]
+pub struct ArbitraryJsonUInt(pub JsonUInt);
+
+impl<'a> arbitrary::Arbitrary<'a> for ArbitraryJsonPathQuery {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let mut builder = JsonPathQueryBuilder::new();
+        let mut u = SafeUnstructured::new(u);
+        ArbitraryQueryGenerator::generate_query(&mut builder, 1, &mut u);
+        Ok(Self(builder.into_query()))
+    }
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for ArbitraryJsonString {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let mut u = SafeUnstructured::new(u);
+        let inner = generate_string(&mut u);
+        u.err_or(Self(inner))
+    }
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for ArbitraryJsonUInt {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let mut u = SafeUnstructured::new(u);
+        let inner = generate_json_uint(&mut u);
+        u.err_or(Self(inner))
+    }
+}
+
+struct ArbitraryQueryGenerator {
+    depth: usize,
+}
+
+impl ArbitraryQueryGenerator {
+    const MAX_QUERY_DEPTH: usize = 3;
+    const MAX_LOGICAL_EXPR_SIZE: usize = 5;
+    const MAX_SEGMENTS: usize = 5;
+    const MAX_SELECTORS: usize = 3;
+
+    fn generate_query<'a>(
+        builder: &'a mut JsonPathQueryBuilder,
+        depth: usize,
+        u: &mut SafeUnstructured,
+    ) -> &'a mut JsonPathQueryBuilder {
+        let mut this = ArbitraryQueryGenerator { depth };
+
+        let len = u.access(|u| u.int_in_range(0..=ArbitraryQueryGenerator::MAX_SEGMENTS));
+        for _ in 0..len {
+            this.generate_segment(builder, u);
+        }
+        builder
+    }
+
+    fn generate_segment(&mut self, builder: &mut JsonPathQueryBuilder, u: &mut SafeUnstructured) {
+        let discriminant = u.access(|u| u.int_in_range(0..=1));
+        if discriminant == 0 {
+            builder.child(|b| self.generate_selectors(b, u));
+        } else {
+            builder.descendant(|b| self.generate_selectors(b, u));
+        }
+    }
+
+    fn generate_selectors<'a>(
+        &self,
+        builder: &'a mut JsonPathSelectorsBuilder,
+        u: &mut SafeUnstructured,
+    ) -> &'a mut JsonPathSelectorsBuilder {
+        let len = u.access(|u| u.int_in_range(1..=Self::MAX_SELECTORS));
+        for _ in 0..len {
+            self.generate_selector(builder, u);
+        }
+        builder
+    }
+
+    fn generate_selector(&self, builder: &mut JsonPathSelectorsBuilder, u: &mut SafeUnstructured) {
+        let discriminant = u.access(|u| u.int_in_range(0..=4));
+        match discriminant {
+            0 => Self::generate_name_selector(builder, u),
+            1 => Self::generate_index_selector(builder, u),
+            2 => Self::generate_slice_selector(builder, u),
+            3 => Self::generate_wildcard_selector(builder, u),
+            4 => self.generate_filter_selector(builder, u),
+            _ => unreachable!(),
+        }
+    }
+
+    fn generate_name_selector(builder: &mut JsonPathSelectorsBuilder, u: &mut SafeUnstructured) {
+        let string = generate_string(u);
+        builder.name(string);
+    }
+
+    fn generate_index_selector(builder: &mut JsonPathSelectorsBuilder, u: &mut SafeUnstructured) {
+        let index = generate_json_int(u);
+        builder.index(index);
+    }
+
+    fn generate_slice_selector(builder: &mut JsonPathSelectorsBuilder, u: &mut SafeUnstructured) {
+        builder.slice(|b| generate_slice(b, u));
+    }
+
+    fn generate_wildcard_selector(builder: &mut JsonPathSelectorsBuilder, _u: &mut SafeUnstructured) {
+        builder.wildcard();
+    }
+
+    fn generate_filter_selector(&self, builder: &mut JsonPathSelectorsBuilder, u: &mut SafeUnstructured) {
+        builder.filter(|b| self.generate_logical_expr(b, u));
+    }
+
+    fn generate_logical_expr(&self, b: EmptyLogicalExprBuilder, u: &mut SafeUnstructured) -> LogicalExprBuilder {
+        let target_depth = u.access(|u| u.int_in_range(1..=Self::MAX_LOGICAL_EXPR_SIZE));
+        return generate_with_depth(self, b, u, target_depth);
+
+        fn generate_with_depth(
+            this: &ArbitraryQueryGenerator,
+            builder: EmptyLogicalExprBuilder,
+            u: &mut SafeUnstructured,
+            target_depth: usize,
+        ) -> LogicalExprBuilder {
+            let discriminant = if this.depth < ArbitraryQueryGenerator::MAX_QUERY_DEPTH {
+                u.access(|u| u.int_in_range(0..=2))
+            } else {
+                0
+            };
+            let builder = match discriminant {
+                0 => builder.comparison(|b| this.generate_comparison(b, u)),
+                1 => builder.test_absolute(|b| this.generate_nested_query(b, u)),
+                2 => builder.test_relative(|b| this.generate_nested_query(b, u)),
+                _ => unreachable!(),
+            };
+            if target_depth == 1 {
+                builder
+            } else {
+                let discriminant = u.access(|u| u.int_in_range(0..=2));
+                match discriminant {
+                    0 => EmptyLogicalExprBuilder.not(|_| builder),
+                    1 => builder.and(|b| generate_with_depth(this, b, u, target_depth - 1)),
+                    2 => builder.or(|b| generate_with_depth(this, b, u, target_depth - 1)),
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
+
+    fn generate_comparison(&self, builder: EmptyComparisonExprBuilder, u: &mut SafeUnstructured) -> ComparisonExpr {
+        let discriminant = u.access(|u| u.int_in_range(0..=2));
+        let lhs = match discriminant {
+            0 => {
+                let literal = generate_literal(u);
+                builder.literal(literal)
+            }
+            1 => builder.query_absolute(|b| self.generate_singular_query(b, u)),
+            2 => builder.query_relative(|b| self.generate_singular_query(b, u)),
+            _ => unreachable!(),
+        };
+        let discriminant = u.access(|u| u.int_in_range(0..=5));
+        let op = match discriminant {
+            0 => lhs.equal_to(),
+            1 => lhs.greater_or_equal_to(),
+            2 => lhs.greater_than(),
+            3 => lhs.less_than(),
+            4 => lhs.lesser_or_equal_to(),
+            5 => lhs.not_equal_to(),
+            _ => unreachable!(),
+        };
+        let discriminant = u.access(|u| u.int_in_range(0..=2));
+        let result = match discriminant {
+            0 => {
+                let literal = generate_literal(u);
+                op.literal(literal)
+            }
+            1 => op.query_absolute(|b| self.generate_singular_query(b, u)),
+            2 => op.query_relative(|b| self.generate_singular_query(b, u)),
+            _ => unreachable!(),
+        };
+        result
+    }
+
+    fn generate_singular_query<'a>(
+        &self,
+        builder: &'a mut SingularJsonPathQueryBuilder,
+        u: &mut SafeUnstructured,
+    ) -> &'a mut SingularJsonPathQueryBuilder {
+        let len = u.access(|u| u.int_in_range(0..=Self::MAX_SEGMENTS));
+        for _ in 0..len {
+            let discriminant = u.access(|u| u.int_in_range(0..=1));
+            match discriminant {
+                0 => builder.index(generate_json_int(u)),
+                1 => builder.name(generate_string(u)),
+                _ => unreachable!(),
+            };
+        }
+        builder
+    }
+
+    fn generate_nested_query<'a>(
+        &self,
+        builder: &'a mut JsonPathQueryBuilder,
+        u: &mut SafeUnstructured,
+    ) -> &'a mut JsonPathQueryBuilder {
+        Self::generate_query(builder, self.depth + 1, u)
+    }
+}
+
+fn generate_literal(u: &mut SafeUnstructured) -> Literal {
+    let discriminant = u.access(|u| u.int_in_range(0..=3));
+    match discriminant {
+        0 => Literal::Null,
+        1 => Literal::Bool(u.access(|u| u.arbitrary::<bool>())),
+        2 => Literal::Number(generate_number(u)),
+        3 => Literal::String(generate_string(u)),
+        _ => unreachable!(),
+    }
+}
+
+fn generate_number(u: &mut SafeUnstructured) -> JsonNumber {
+    let discriminant = u.access(|u| u.int_in_range(0..=1));
+    match discriminant {
+        0 => JsonNumber::from(generate_json_int(u)),
+        1 => JsonNumber::from(generate_json_float(u)),
+        _ => unreachable!(),
+    }
+}
+
+fn generate_json_int(u: &mut SafeUnstructured) -> JsonInt {
+    u.access(|u| {
+        let val = u.int_in_range(JsonInt::MIN.as_i64()..=JsonInt::MAX.as_i64())?;
+        let int = JsonInt::try_from(val).expect("int is in range above and should succeed");
+        Ok(int)
+    })
+}
+
+fn generate_json_uint(u: &mut SafeUnstructured) -> JsonUInt {
+    u.access(|u| {
+        let val = u.int_in_range(0..=JsonUInt::MAX.as_u64())?;
+        let int = JsonUInt::try_from(val).expect("uint is in range above and should succeed");
+        Ok(int)
+    })
+}
+
+fn generate_json_float(u: &mut SafeUnstructured) -> JsonFloat {
+    struct SafeFloat(JsonFloat);
+    impl Default for SafeFloat {
+        fn default() -> Self {
+            SafeFloat(JsonFloat::ZERO)
+        }
+    }
+
+    u.access(|u| {
+        let val = u.arbitrary::<f64>()?;
+        // Wrap NaN, +Inf, -Inf into zero.
+        let val = if val.is_nan() {
+            0.0
+        } else if val.is_infinite() {
+            0.0_f64.copysign(val)
+        } else {
+            val
+        };
+
+        Ok(SafeFloat(
+            JsonFloat::try_from(val).expect("the above construction should always give correct values"),
+        ))
+    })
+    .0
+}
+
+fn generate_string(u: &mut SafeUnstructured) -> JsonString {
+    struct SafeString(JsonString);
+    impl Default for SafeString {
+        fn default() -> Self {
+            SafeString(JsonString::new(""))
+        }
+    }
+
+    u.access(|u| {
+        let iter = u.arbitrary_iter::<char>()?.map(|x| x.unwrap_or_default());
+        Ok(SafeString(JsonString::from_iter(iter)))
+    })
+    .0
+}
+
+fn generate_slice<'a>(builder: &'a mut SliceBuilder, u: &mut SafeUnstructured) -> &'a mut SliceBuilder {
+    let (has_start, has_end, has_step) = u.access(|u| Ok((u.arbitrary()?, u.arbitrary()?, u.arbitrary()?)));
+    if has_start {
+        let int = generate_json_int(u);
+        builder.with_start(int);
+    }
+    if has_end {
+        let int = generate_json_int(u);
+        builder.with_end(int);
+    }
+    if has_step {
+        let int = generate_json_int(u);
+        builder.with_step(int);
+    }
+    builder
+}


### PR DESCRIPTION
## Short description

Following advice from rust-fuzz (https://github.com/rust-fuzz/libfuzzer/issues/138) I reworked the `Arbitrary` implementations used by the fuzzer to have explicit caps on size and recursion depth.

Arbitrary JSONPath queries have a limit on max number of segments and selectors per segment, as well as a recursion limit for filter expressions and a more restrictive one specifically for recursive queries within filter expressions.

The arbitrary JSON generator has a limit on the overall number of nodes.

The `arbitrary` feature is removed from `rsonpath-syntax` and the impls are now in the library target of the fuzzer.

On my machine I can run all fuzzers for an hour without exceeding the 2560 rss limit. Hopefully, this will resolve our fuzzing oom issues.

## Issue

Resolves: #749

## Checklist

All of these should be ticked off before you submit the PR.

- [x] I ran `just verify` locally and it succeeded.
- [x] Issue was given <span style="color: #FF4400">go ahead</span> and is linked above **OR** I have included justification for a minor change.
- [x] Unit tests for my changes are included **OR** no functionality was changed.