### PR TITLE
fix: clippy warnings

### DIFF
--- a/crates/rsonpath-lib/src/engine/main.rs
+++ b/crates/rsonpath-lib/src/engine/main.rs
@@ -704,8 +704,8 @@ where
         debug!("Reporting result somewhere after {start_idx} with node type {ty:?}");
 
         let index = match ty {
-            NodeType::Complex(BracketType::Curly) => self.input.seek_forward(start_idx, [b'{']).e()?,
-            NodeType::Complex(BracketType::Square) => self.input.seek_forward(start_idx, [b'[']).e()?,
+            NodeType::Complex(BracketType::Curly) => self.input.seek_forward(start_idx, *b"{").e()?,
+            NodeType::Complex(BracketType::Square) => self.input.seek_forward(start_idx, *b"[").e()?,
             NodeType::Atomic => self.input.seek_non_whitespace_forward(start_idx).e()?,
         }
         .map(|x| x.0);

--- a/crates/rsonpath-lib/src/lib.rs
+++ b/crates/rsonpath-lib/src/lib.rs
@@ -302,7 +302,7 @@ impl<F: FallibleIterator> Iterator for FallibleIntoIter<F> {
 
 pub(crate) const JSON_SPACE_BYTE: u8 = b' ';
 
-pub(crate) const JSON_WHITESPACE_BYTES: [u8; 4] = [b' ', b'\t', b'\n', b'\r'];
+pub(crate) const JSON_WHITESPACE_BYTES: [u8; 4] = *b" \t\n\r";
 
 #[inline(always)]
 #[must_use]

--- a/crates/rsonpath-lib/src/result/nodes.rs
+++ b/crates/rsonpath-lib/src/result/nodes.rs
@@ -442,7 +442,7 @@ fn finalize_node(buf: &mut Vec<u8>, ty: MatchedNodeType) {
         // We need to remove it before saving the result.
         if buf.len() <= 1 {
             // This should never happen in a valid JSON, but we also don't want to panic if the file is invalid.
-            buf.truncate(0)
+            buf.clear();
         } else {
             let mut i = buf.len() - 2;
             while is_json_whitespace(buf[i]) {

--- a/crates/rsonpath-syntax/src/error/display.rs
+++ b/crates/rsonpath-syntax/src/error/display.rs
@@ -414,8 +414,8 @@ impl super::SyntaxError {
                     }
 
                     // If it's brackets or commas then we can try to fix the selector.
-                    if [b'[', b','].contains(&input_bytes[start_boundary])
-                        && [b']', b','].contains(&input_bytes[end_boundary])
+                    if b"[,".contains(&input_bytes[start_boundary])
+                        && b"],".contains(&input_bytes[end_boundary])
                     {
                         // The invalid selector is bracketed, so the user might've meant to search for the string inside
                         // but forgot the quotes. Try to fix it if possible.

--- a/crates/rsonpath-syntax/src/error/style.rs
+++ b/crates/rsonpath-syntax/src/error/style.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "color")]
 pub(super) mod colored {
-    use super::super::{fmt_parse_error, ParseError};
+    use super::super::{ParseError, fmt_parse_error};
     use std::fmt::{self, Display};
     use thiserror::Error;
 
@@ -165,6 +165,7 @@ pub(super) mod plain {
             target
         }
 
+        #[allow(clippy::unused_self)]
         pub(crate) fn truncation_marks<'a, D: Display>(&self, target: &'a D) -> impl Display + 'a {
             target
         }


### PR DESCRIPTION
## Short description

Replaced byte array literals to fix `clippy::byte_char_slices warnings` (Rust >= 1.81.0).

## Issue

Resolves: #949 

## Checklist

All of these should be ticked off before you submit the PR.

- [x] I ran `just verify` locally and it succeeded.
- [x] Issue was given <span style="color: #FF4400">go ahead</span> and is linked above **OR** I have included justification for a minor change.
- [x] Unit tests for my changes are included **OR** no functionality was changed.