### PR TITLE
fix: head-skipping dropping matches in rare circumstances

### DIFF
--- a/crates/rsonpath-benchmarks/Cargo.toml
+++ b/crates/rsonpath-benchmarks/Cargo.toml
@@ -30,7 +30,7 @@ jsonpath-rust = "1.0.4"
 lazy_static = "1.5.0"
 serde_json = "1.0.149"
 sha2 = "0.11.0"
-reqwest = { version = "0.13.1", features = ["blocking"] }
+reqwest = { version = "0.13.4", features = ["blocking"] }
 rsonpath-lib = { version = "0.10.0", default-features = false }
 rsonpath-syntax = { version = "0.4.0", default-features = false }
 serde_json_path = "0.7.2"

--- a/crates/rsonpath-lib/src/engine/head_skipping.rs
+++ b/crates/rsonpath-lib/src/engine/head_skipping.rs
@@ -151,12 +151,12 @@ impl<'b, I: Input, V: Simd> HeadSkip<'b, I, V, BLOCK_SIZE> {
                     debug!("Needle found at {idx}");
                     let seek_start_idx = idx + head_skip.member_name.quoted().len();
 
-                match head_skip.bytes.seek_non_whitespace_forward(seek_start_idx).e()? {
-                    Some((colon_idx, b':')) => {
-                        let (next_idx, next_c) = head_skip
-                            .bytes
-                            .seek_non_whitespace_forward(colon_idx + 1).e()?
-                            .ok_or(EngineError::MissingItem())?;
+                    match head_skip.bytes.seek_non_whitespace_forward(seek_start_idx).e()? {
+                        Some((colon_idx, b':')) => {
+                            let (next_idx, next_c) = head_skip
+                                .bytes
+                                .seek_non_whitespace_forward(colon_idx + 1).e()?
+                                .ok_or(EngineError::MissingItem())?;
 
                             let ResumedQuoteClassifier {
                                 classifier: quote_classifier,
@@ -254,7 +254,7 @@ impl<'b, I: Input, V: Simd> HeadSkip<'b, I, V, BLOCK_SIZE> {
                             debug!("Quote classified up to {}", classifier_state.get_idx());
                             idx = classifier_state.get_idx();
 
-                            first_block = classifier_state.block.map(|b| b.quote_classified.block);
+                            first_block = classifier_state.block.and_then(|b| (b.idx < BLOCK_SIZE).then_some(b.quote_classified.block));
                             input_iter = classifier_state.iter.into_inner();
                         }
                         _ => idx += 1,

--- a/crates/rsonpath-test/documents/toml/head_skip_first_block_end.toml
+++ b/crates/rsonpath-test/documents/toml/head_skip_first_block_end.toml
@@ -1,0 +1,27 @@
+# Define the JSON input for all query test cases.
+[input]
+# Short description of the input structure.
+description = """Issue #971. Force head skipping to stop in a block that ends in a structural and resume from there.
+The second match must align its quote with a quote in the first block."""
+ # Set to true only if your specific test input is fully compressed (no extraneous whitespace).
+is_compressed = true
+
+# Inline JSON document.
+[input.source]
+json_string = '{"values":[{"needle":"This string has exactly forty characters"},{"needle":"other"},{"needle":"final"}]}'
+
+# Define queries to test on the input.
+[[queries]]
+ # Valid JSONPath query string.
+query = '$..needle'
+# Short descritpion of the query semantics.
+description = "descendant search for the needle"
+
+[queries.results]
+# Number of expected matches.
+count = 3
+# Byte locations of spans of all matches, in order.
+spans = [[21, 63], [75, 82], [94,101]]
+# Stringified values of all matches, verbatim as in the input,
+# in the same order as above.
+nodes = ['"This string has exactly forty characters"', '"other"', '"final"']

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "memchr"
@@ -258,9 +258,9 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "vector-map"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b34e878e32c750bb4253be124adb9da1dc93ca5d98c210787badf1e1ccdca7"
+checksum = "0dfc85d5e0ff077e86e69d0a9342a7ba0de8d22f693e580b36ac950195962018"
 
 [[package]]
 name = "zmij"


### PR DESCRIPTION
## Short description

Head-skipping would incorrectly start from the start of a block if quote classification dropped it at the final structural character. In rare cases where a quote in that block aligned with the start of a match in the next block it would cause the engine to miss matching results.

The fix is to manually check if the block is still valid, i.e. idx != BLOCK_SIZE before continuing memmem.

## Issue

Resolves: #971

## Checklist

All of these should be ticked off before you submit the PR.

- [x] I ran `just verify` locally and it succeeded.
- [x] Issue was given <span style="color: #FF4400">go ahead</span> and is linked above **OR** I have included justification for a minor change.
- [x] Unit tests for my changes are included **OR** no functionality was changed.