### PR TITLE
fix: ParseError Display panic on zero-length filter errors at end of input (#975)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -112,7 +112,11 @@ test-engine: (gen-tests)
 test-input:
     cargo test --test input_implementation_tests -q
 
-# Run the query tests on default features.
+# Run the rsonpath-syntax tests.
+test-syntax:
+    cargo test -p rsonpath-syntax -q
+
+# Run the query parser tests on default features.
 test-parser:
     cargo test --test query_parser_tests -q
 

--- a/crates/rsonpath-syntax/src/error.rs
+++ b/crates/rsonpath-syntax/src/error.rs
@@ -139,6 +139,7 @@ pub(crate) enum SyntaxErrorKind {
 
 impl SyntaxError {
     pub(crate) fn new(kind: SyntaxErrorKind, rev_idx: usize, len: usize) -> Self {
+        assert_ne!(len, 0, "do not create zero-length errors");
         Self { kind, rev_idx, len }
     }
 }

--- a/crates/rsonpath-syntax/src/error/display.rs
+++ b/crates/rsonpath-syntax/src/error/display.rs
@@ -180,11 +180,7 @@ impl super::SyntaxError {
         style: ErrorStyleImpl,
     ) -> DisplayableSyntaxError {
         let start_idx = input.len() - self.rev_idx;
-        let end_idx = if self.len > 0 {
-            start_idx + self.len - 1
-        } else {
-            start_idx
-        };
+        let end_idx = start_idx + self.len - 1;
 
         let lines = input.build_error_lines(
             start_idx,
@@ -210,11 +206,7 @@ impl super::SyntaxError {
     fn generate_notes(&self, suggestion: &mut Suggestion, input: &str) -> Vec<SyntaxErrorNote> {
         // Figure out the first and last byte of the highlighted error. Errors always respect UTF-8 boundaries.
         let start_idx = input.len() - self.rev_idx;
-        let end_idx = if self.len > 0 {
-            start_idx + self.len - 1
-        } else {
-            start_idx
-        };
+        let end_idx = start_idx + self.len - 1;
         let (prefix, error, suffix) = self.split_error(input);
         // Kind-specific notes and suggestion building.
         let mut notes = vec![];

--- a/crates/rsonpath-syntax/src/error/display.rs
+++ b/crates/rsonpath-syntax/src/error/display.rs
@@ -180,7 +180,11 @@ impl super::SyntaxError {
         style: ErrorStyleImpl,
     ) -> DisplayableSyntaxError {
         let start_idx = input.len() - self.rev_idx;
-        let end_idx = start_idx + self.len - 1;
+        let end_idx = if self.len > 0 {
+            start_idx + self.len - 1
+        } else {
+            start_idx
+        };
 
         let lines = input.build_error_lines(
             start_idx,
@@ -206,7 +210,11 @@ impl super::SyntaxError {
     fn generate_notes(&self, suggestion: &mut Suggestion, input: &str) -> Vec<SyntaxErrorNote> {
         // Figure out the first and last byte of the highlighted error. Errors always respect UTF-8 boundaries.
         let start_idx = input.len() - self.rev_idx;
-        let end_idx = start_idx + self.len - 1;
+        let end_idx = if self.len > 0 {
+            start_idx + self.len - 1
+        } else {
+            start_idx
+        };
         let (prefix, error, suffix) = self.split_error(input);
         // Kind-specific notes and suggestion building.
         let mut notes = vec![];

--- a/crates/rsonpath-syntax/src/parser.rs
+++ b/crates/rsonpath-syntax/src/parser.rs
@@ -661,7 +661,8 @@ fn failed_filter_expression<T>(kind: SyntaxErrorKind) -> impl FnMut(&str) -> IRe
     move |q: &str| {
         // We want to close the filter, so just try to find the next ']' or ','
         let rest = skip_one(q).trim_start_matches(|x| x != ',' && x != ']');
-        fail(kind.clone(), q.len(), q.len() - rest.len(), rest)
+        let len = (q.len() - rest.len()).max(1);
+        fail(kind.clone(), q.len(), len, rest)
     }
 }
 

--- a/crates/rsonpath-syntax/tests/error_snapshots.rs
+++ b/crates/rsonpath-syntax/tests/error_snapshots.rs
@@ -879,6 +879,121 @@ mod filter_error_at_end_of_input {
     }
 }
 
+mod missing_at_end {
+    use insta::assert_snapshot;
+    use rsonpath_syntax::parse;
+
+    #[test]
+    fn missing_after_child() {
+        let src = "$.";
+        let result = parse(src).expect_err("should fail to parse");
+
+        assert_snapshot!(result, @"
+        error: invalid selector - empty
+
+          $.
+           ^^ expected a selector here, but found nothing
+          (bytes 1-2)
+
+        note: if you meant to match any value, you should use the wildcard selector `*`
+        suggestion: did you mean `$.*` ?
+        ");
+    }
+
+    #[test]
+    fn missing_after_descendant() {
+        let src = "$..";
+        let result = parse(src).expect_err("should fail to parse");
+
+        assert_snapshot!(result, @"
+        error: invalid selector - empty
+
+          $..
+            ^^ expected a selector here, but found nothing
+          (bytes 2-3)
+
+        note: if you meant to match any value, you should use the wildcard selector `*`
+        suggestion: did you mean `$..*` ?
+        ");
+    }
+
+    #[test]
+    fn missing_after_bracket() {
+        let src = "$[";
+        let result = parse(src).expect_err("should fail to parse");
+
+        assert_snapshot!(result, @"
+        error: invalid selector - empty
+
+          $[
+           ^^ expected a selector here, but found nothing
+          (bytes 1-2)
+
+        note: if you meant to match any value, you should use the wildcard selector `*`
+        error: bracketed selection is not closed
+
+          $[
+            ^ expected a closing bracket ']'
+          (byte 2)
+
+
+        suggestion: did you mean `$[*]` ?
+        ");
+    }
+
+    #[test]
+    fn missing_in_brackets() {
+        let src = "$[]";
+        let result = parse(src).expect_err("should fail to parse");
+
+        assert_snapshot!(result, @"
+        error: invalid selector - empty
+
+          $[]
+           ^^ expected a selector here, but found nothing
+          (bytes 1-2)
+
+        note: if you meant to match any value, you should use the wildcard selector `*`
+        suggestion: did you mean `$[*]` ?
+        ");
+    }
+
+    #[test]
+    fn missing_after_paren() {
+        let src = "$[?(";
+        let result = parse(src).expect_err("should fail to parse");
+
+        assert_snapshot!(result, @"
+        error: invalid filter expression syntax
+
+          $[?(
+              ^ not a valid filter expression
+          (byte 4)
+
+
+        error: bracketed selection is not closed
+
+          $[?(
+              ^ expected a closing bracket ']'
+          (byte 4)
+        ");
+    }
+
+    #[test]
+    fn missing_in_parens() {
+        let src = "$[?()]";
+        let result = parse(src).expect_err("should fail to parse");
+
+        assert_snapshot!(result, @"
+        error: invalid filter expression syntax
+
+          $[?()]
+              ^ not a valid filter expression
+          (byte 4)
+        ");
+    }
+}
+
 mod multiline {
     // These are too long to be useful so we use the out-of-line snapshots.
     use insta::assert_snapshot;

--- a/crates/rsonpath-syntax/tests/error_snapshots.rs
+++ b/crates/rsonpath-syntax/tests/error_snapshots.rs
@@ -835,6 +835,50 @@ mod escaped_sequence_suggestions {
     }
 }
 
+/// Verify that a filter expression error produced at end of input is properly highlighted
+mod filter_error_at_end_of_input {
+    use insta::assert_snapshot;
+    use rsonpath_syntax::parse;
+
+    #[test]
+    fn incomplete_filter_selector() {
+        let result = parse("$.a[?").expect_err("should fail to parse");
+        assert_snapshot!(result, @"
+        error: invalid filter expression syntax
+
+          $.a[?
+               ^ not a valid filter expression
+          (byte 5)
+
+
+        error: bracketed selection is not closed
+
+          $.a[?
+               ^ expected a closing bracket ']'
+          (byte 5)
+        ");
+    }
+
+    #[test]
+    fn filter_comparison_missing_rhs() {
+        let result = parse("$[?@.b ==").expect_err("should fail to parse");
+        assert_snapshot!(result, @"
+        error: invalid right-hand side of comparison
+
+          $[?@.b ==
+                   ^ expected a literal or a filter query here
+          (byte 9)
+
+
+        error: bracketed selection is not closed
+
+          $[?@.b ==
+                   ^ expected a closing bracket ']'
+          (byte 9)
+        ");
+    }
+}
+
 mod multiline {
     // These are too long to be useful so we use the out-of-line snapshots.
     use insta::assert_snapshot;


### PR DESCRIPTION

When a filter expression fails at end of input the parser emits a SyntaxError with len=0. The display code computed end_idx as start_idx + len - 1, producing an inverted byte span (end < start). This caused an arithmetic underflow in formatter::width_of_char_span when it subtracted the higher accumulated width from the lower one.

- error/display.rs: clamp end_idx to start_idx when len == 0, in both display() and generate_notes()
- tests/error_snapshots.rs: add regression snapshots for "$.a[?" and "$[?@.b =="

## Issue

Resolves: #975
